### PR TITLE
Add I2S/SAI pad info

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ description = """Pad configuration interface for NXP i.MX RT processors.
 
 Part of the imxrt-rs project.
 """
-repository = "https://github.com/imxrt-rs/imxrt-rs"
+repository = "https://github.com/imxrt-rs/imxrt-iomuxc"
 license = "MIT OR Apache-2.0"
 keywords = ["imxrt", "nxp", "embedded", "no_std"]
 categories = ["embedded", "no-std"]

--- a/daisy.py
+++ b/daisy.py
@@ -5,7 +5,7 @@ Generate Daisy constants from an i.MX RT SVD file
 
 Example usage: to create SPI-related Daisy constants,
 
-    ./process.py path/to/imxrt.svd | grep LPSPI
+    ./daisy.py path/to/imxrt.svd | grep LPSPI
 
 Copy and paste the constants into a Rust module.
 """

--- a/src/imxrt1060/mod.rs
+++ b/src/imxrt1060/mod.rs
@@ -91,6 +91,7 @@
 mod adc;
 mod i2c;
 mod pwm;
+mod sai;
 mod spi;
 mod uart;
 

--- a/src/imxrt1060/sai.rs
+++ b/src/imxrt1060/sai.rs
@@ -1,0 +1,192 @@
+//! SAI / I2S pin implementation
+
+use super::{ad_b0::*, ad_b1::*, b0::*, b1::*, emc::*, sd_b1::*};
+use crate::{consts::*, sai::*, Daisy};
+
+/// SAI1 multiplexed TX / RX pin
+///
+/// Implements both `RxDataSignal` and `TxDataSignal`.
+pub enum TxData1RxData3 {}
+/// SAI1 multiplexed TX / RX pin
+///
+/// Implements both `RxDataSignal` and `TxDataSignal`.
+pub enum TxData2RxData2 {}
+/// SAI1 multiplexed TX / RX pin
+///
+/// Implements both `RxDataSignal` and `TxDataSignal`.
+pub enum TxData3RxData1 {}
+
+impl Signal for TxData1RxData3 {}
+impl TxDataSignal for TxData1RxData3 {
+    type Index = U1;
+}
+impl RxDataSignal for TxData1RxData3 {
+    type Index = U3;
+}
+
+impl Signal for TxData2RxData2 {}
+impl TxDataSignal for TxData2RxData2 {
+    type Index = U2;
+}
+impl RxDataSignal for TxData2RxData2 {
+    type Index = U2;
+}
+
+impl Signal for TxData3RxData1 {}
+impl TxDataSignal for TxData3RxData1 {
+    type Index = U3;
+}
+impl RxDataSignal for TxData3RxData1 {
+    type Index = U1;
+}
+
+impl private::Sealed for TxData1RxData3 {}
+impl private::Sealed for TxData2RxData2 {}
+impl private::Sealed for TxData3RxData1 {}
+
+//
+// SAI1
+//
+
+sai! { module: U1, alt: 3, pad: SD_B1_08, signal: TxBclk, daisy: Some(DAISY_SAI1_TX_BCLK_SD_B1_08) }
+sai! { module: U1, alt: 3, pad: B1_02,    signal: TxBclk, daisy: Some(DAISY_SAI1_TX_BCLK_B1_02) }
+sai! { module: U1, alt: 3, pad: AD_B1_14, signal: TxBclk, daisy: Some(DAISY_SAI1_TX_BCLK_AD_B1_14) }
+
+sai! { module: U1, alt: 3, pad: AD_B1_15, signal: TxSync, daisy: Some(DAISY_SAI1_TX_SYNC_AD_B1_15) }
+sai! { module: U1, alt: 3, pad: B1_03,    signal: TxSync, daisy: Some(DAISY_SAI1_TX_SYNC_B1_03) }
+sai! { module: U1, alt: 3, pad: SD_B1_09, signal: TxSync, daisy: Some(DAISY_SAI1_TX_SYNC_SD_B1_09) }
+
+sai! { module: U1, alt: 3, pad: B0_13,    signal: Mclk, daisy: Some(DAISY_SAI1_MCLK2_B0_13) }
+sai! { module: U1, alt: 3, pad: SD_B1_03, signal: Mclk, daisy: Some(DAISY_SAI1_MCLK2_SD_B1_03) }
+sai! { module: U1, alt: 3, pad: AD_B1_09, signal: Mclk, daisy: Some(DAISY_SAI1_MCLK2_AD_B1_09) }
+
+sai! { module: U1, alt: 3, pad: AD_B1_11, signal: RxBclk, daisy: Some(DAISY_SAI1_RX_BCLK_AD_B1_11) }
+sai! { module: U1, alt: 3, pad: B0_15,    signal: RxBclk, daisy: Some(DAISY_SAI1_RX_BCLK_B0_15) }
+sai! { module: U1, alt: 3, pad: SD_B1_05, signal: RxBclk, daisy: Some(DAISY_SAI1_RX_BCLK_SD_B1_05) }
+
+sai! { module: U1, alt: 3, pad: AD_B1_10, signal: RxSync, daisy: Some(DAISY_SAI1_RX_SYNC_AD_B1_10) }
+sai! { module: U1, alt: 3, pad: SD_B1_04, signal: RxSync, daisy: Some(DAISY_SAI1_RX_SYNC_SD_B1_04) }
+sai! { module: U1, alt: 3, pad: B0_14,    signal: RxSync, daisy: Some(DAISY_SAI1_RX_SYNC_B0_14) }
+
+sai! { module: U1, alt: 3, pad: AD_B1_13, signal: TxData, daisy: None }
+sai! { module: U1, alt: 3, pad: B1_01,    signal: TxData, daisy: None }
+sai! { module: U1, alt: 3, pad: SD_B1_07, signal: TxData, daisy: None }
+
+sai! { module: U1, alt: 3, pad: B1_00,    signal: RxData, daisy: Some(DAISY_SAI1_RX_DATA0_B1_00) }
+sai! { module: U1, alt: 3, pad: AD_B1_12, signal: RxData, daisy: Some(DAISY_SAI1_RX_DATA0_AD_B1_12) }
+sai! { module: U1, alt: 3, pad: SD_B1_06, signal: RxData, daisy: Some(DAISY_SAI1_RX_DATA0_SD_B1_06) }
+
+sai! { module: U1, alt: 3, pad: B0_12,    signal: TxData1RxData3, daisy: Some(DAISY_SAI1_RX_DATA3_B0_12) }
+sai! { module: U1, alt: 3, pad: SD_B1_02, signal: TxData1RxData3, daisy: Some(DAISY_SAI1_RX_DATA3_SD_B1_02) }
+
+sai! { module: U1, alt: 3, pad: B0_11,    signal: TxData2RxData2, daisy: Some(DAISY_SAI1_RX_DATA2_B0_11) }
+sai! { module: U1, alt: 3, pad: SD_B1_01, signal: TxData2RxData2, daisy: Some(DAISY_SAI1_RX_DATA2_SD_B1_01) }
+
+sai! { module: U1, alt: 3, pad: B0_10,    signal: TxData3RxData1, daisy: Some(DAISY_SAI1_RX_DATA1_B0_10) }
+sai! { module: U1, alt: 3, pad: SD_B1_00, signal: TxData3RxData1, daisy: Some(DAISY_SAI1_RX_DATA1_SD_B1_00) }
+
+//
+// SAI2
+//
+
+sai! { module: U2, alt: 3, pad: AD_B0_05, signal: TxBclk, daisy: Some(DAISY_SAI2_TX_BCLK_AD_B0_05) }
+sai! { module: U2, alt: 2, pad: EMC_06,   signal: TxBclk, daisy: Some(DAISY_SAI2_TX_BCLK_EMC_06) }
+
+sai! { module: U2, alt: 3, pad: AD_B0_04, signal: TxSync, daisy: Some(DAISY_SAI2_TX_SYNC_AD_B0_04) }
+sai! { module: U2, alt: 2, pad: EMC_05,   signal: TxSync, daisy: Some(DAISY_SAI2_TX_SYNC_EMC_05) }
+
+sai! { module: U2, alt: 2, pad: EMC_10,   signal: RxBclk, daisy: Some(DAISY_SAI2_RX_BCLK_EMC_10) }
+sai! { module: U2, alt: 3, pad: AD_B0_06, signal: RxBclk, daisy: Some(DAISY_SAI2_RX_BCLK_AD_B0_06) }
+
+sai! { module: U2, alt: 2, pad: EMC_09,   signal: RxSync, daisy: Some(DAISY_SAI2_RX_SYNC_EMC_09) }
+sai! { module: U2, alt: 3, pad: AD_B0_07, signal: RxSync, daisy: Some(DAISY_SAI2_RX_SYNC_AD_B0_07) }
+
+sai! { module: U2, alt: 2, pad: EMC_07,   signal: Mclk, daisy: Some(DAISY_SAI2_MCLK2_EMC_07) }
+sai! { module: U2, alt: 3, pad: AD_B0_10, signal: Mclk, daisy: Some(DAISY_SAI2_MCLK2_AD_B0_10) }
+
+sai! { module: U2, alt: 2, pad: EMC_04,   signal: TxData, daisy: None }
+sai! { module: U2, alt: 3, pad: AD_B0_09, signal: TxData, daisy: None }
+
+sai! { module: U2, alt: 3, pad: AD_B0_08, signal: RxData, daisy: Some(DAISY_SAI2_RX_DATA0_AD_B0_08) }
+sai! { module: U2, alt: 2, pad: EMC_08,   signal: RxData, daisy: Some(DAISY_SAI2_RX_DATA0_EMC_08) }
+
+//
+// SAI3
+//
+
+sai! { module: U3, alt: 3, pad: EMC_38,   signal: TxBclk, daisy: Some(DAISY_SAI3_IPP_IND_SAI_TXBCLK_EMC_38) }
+sai! { module: U3, alt: 8, pad: SD_B1_03, signal: TxBclk, daisy: Some(DAISY_SAI3_IPP_IND_SAI_TXBCLK_SD_B1_03) }
+
+sai! { module: U3, alt: 3, pad: EMC_39,   signal: TxSync, daisy: Some(DAISY_SAI3_IPP_IND_SAI_TXSYNC_EMC_39) }
+sai! { module: U3, alt: 8, pad: SD_B1_02, signal: TxSync, daisy: Some(DAISY_SAI3_IPP_IND_SAI_TXSYNC_SD_B1_02) }
+
+sai! { module: U3, alt: 3, pad: EMC_35,   signal: RxBclk, daisy: Some(DAISY_SAI3_IPP_IND_SAI_RXBCLK_EMC_35) }
+sai! { module: U3, alt: 8, pad: SD_B1_06, signal: RxBclk, daisy: Some(DAISY_SAI3_IPP_IND_SAI_RXBCLK_SD_B1_06) }
+
+sai! { module: U3, alt: 3, pad: EMC_34,   signal: RxSync, daisy: Some(DAISY_SAI3_IPP_IND_SAI_RXSYNC_EMC_34) }
+sai! { module: U3, alt: 8, pad: SD_B1_05, signal: RxSync, daisy: Some(DAISY_SAI3_IPP_IND_SAI_RXSYNC_SD_B1_05) }
+
+sai! { module: U3, alt: 3, pad: EMC_37,   signal: Mclk, daisy: Some(DAISY_SAI3_IPG_CLK_SAI_MCLK_2_EMC_37) }
+sai! { module: U3, alt: 8, pad: SD_B1_04, signal: Mclk, daisy: Some(DAISY_SAI3_IPG_CLK_SAI_MCLK_2_SD_B1_04) }
+
+sai! { module: U3, alt: 3, pad: EMC_36,   signal: TxData, daisy: None }
+sai! { module: U3, alt: 8, pad: SD_B1_01, signal: TxData, daisy: None }
+
+sai! { module: U3, alt: 3, pad: EMC_33,   signal: RxData, daisy: Some(DAISY_SAI3_IPP_IND_SAI_RXDATA_0_EMC_33) }
+sai! { module: U3, alt: 8, pad: SD_B1_00, signal: RxData, daisy: Some(DAISY_SAI3_IPP_IND_SAI_RXDATA_0_SD_B1_00) }
+
+mod daisy {
+    use super::Daisy;
+
+    pub const DAISY_SAI1_MCLK2_SD_B1_03: Daisy = Daisy::new(0x401f858c as *mut u32, 0);
+    pub const DAISY_SAI1_MCLK2_AD_B1_09: Daisy = Daisy::new(0x401f858c as *mut u32, 1);
+    pub const DAISY_SAI1_MCLK2_B0_13: Daisy = Daisy::new(0x401f858c as *mut u32, 2);
+    pub const DAISY_SAI1_RX_BCLK_SD_B1_05: Daisy = Daisy::new(0x401f8590 as *mut u32, 0);
+    pub const DAISY_SAI1_RX_BCLK_AD_B1_11: Daisy = Daisy::new(0x401f8590 as *mut u32, 1);
+    pub const DAISY_SAI1_RX_BCLK_B0_15: Daisy = Daisy::new(0x401f8590 as *mut u32, 2);
+    pub const DAISY_SAI1_RX_DATA0_SD_B1_06: Daisy = Daisy::new(0x401f8594 as *mut u32, 0);
+    pub const DAISY_SAI1_RX_DATA0_AD_B1_12: Daisy = Daisy::new(0x401f8594 as *mut u32, 1);
+    pub const DAISY_SAI1_RX_DATA0_B1_00: Daisy = Daisy::new(0x401f8594 as *mut u32, 2);
+    pub const DAISY_SAI1_RX_DATA1_SD_B1_00: Daisy = Daisy::new(0x401f8598 as *mut u32, 0);
+    pub const DAISY_SAI1_RX_DATA1_B0_10: Daisy = Daisy::new(0x401f8598 as *mut u32, 1);
+    pub const DAISY_SAI1_RX_DATA2_SD_B1_01: Daisy = Daisy::new(0x401f859c as *mut u32, 0);
+    pub const DAISY_SAI1_RX_DATA2_B0_11: Daisy = Daisy::new(0x401f859c as *mut u32, 1);
+    pub const DAISY_SAI1_RX_DATA3_SD_B1_02: Daisy = Daisy::new(0x401f85a0 as *mut u32, 0);
+    pub const DAISY_SAI1_RX_DATA3_B0_12: Daisy = Daisy::new(0x401f85a0 as *mut u32, 1);
+    pub const DAISY_SAI1_RX_SYNC_SD_B1_04: Daisy = Daisy::new(0x401f85a4 as *mut u32, 0);
+    pub const DAISY_SAI1_RX_SYNC_AD_B1_10: Daisy = Daisy::new(0x401f85a4 as *mut u32, 1);
+    pub const DAISY_SAI1_RX_SYNC_B0_14: Daisy = Daisy::new(0x401f85a4 as *mut u32, 2);
+    pub const DAISY_SAI1_TX_BCLK_SD_B1_08: Daisy = Daisy::new(0x401f85a8 as *mut u32, 0);
+    pub const DAISY_SAI1_TX_BCLK_AD_B1_14: Daisy = Daisy::new(0x401f85a8 as *mut u32, 1);
+    pub const DAISY_SAI1_TX_BCLK_B1_02: Daisy = Daisy::new(0x401f85a8 as *mut u32, 2);
+    pub const DAISY_SAI1_TX_SYNC_SD_B1_09: Daisy = Daisy::new(0x401f85ac as *mut u32, 0);
+    pub const DAISY_SAI1_TX_SYNC_AD_B1_15: Daisy = Daisy::new(0x401f85ac as *mut u32, 1);
+    pub const DAISY_SAI1_TX_SYNC_B1_03: Daisy = Daisy::new(0x401f85ac as *mut u32, 2);
+    pub const DAISY_SAI2_MCLK2_EMC_07: Daisy = Daisy::new(0x401f85b0 as *mut u32, 0);
+    pub const DAISY_SAI2_MCLK2_AD_B0_10: Daisy = Daisy::new(0x401f85b0 as *mut u32, 1);
+    pub const DAISY_SAI2_RX_BCLK_EMC_10: Daisy = Daisy::new(0x401f85b4 as *mut u32, 0);
+    pub const DAISY_SAI2_RX_BCLK_AD_B0_06: Daisy = Daisy::new(0x401f85b4 as *mut u32, 1);
+    pub const DAISY_SAI2_RX_DATA0_EMC_08: Daisy = Daisy::new(0x401f85b8 as *mut u32, 0);
+    pub const DAISY_SAI2_RX_DATA0_AD_B0_08: Daisy = Daisy::new(0x401f85b8 as *mut u32, 1);
+    pub const DAISY_SAI2_RX_SYNC_EMC_09: Daisy = Daisy::new(0x401f85bc as *mut u32, 0);
+    pub const DAISY_SAI2_RX_SYNC_AD_B0_07: Daisy = Daisy::new(0x401f85bc as *mut u32, 1);
+    pub const DAISY_SAI2_TX_BCLK_EMC_06: Daisy = Daisy::new(0x401f85c0 as *mut u32, 0);
+    pub const DAISY_SAI2_TX_BCLK_AD_B0_05: Daisy = Daisy::new(0x401f85c0 as *mut u32, 1);
+    pub const DAISY_SAI2_TX_SYNC_EMC_05: Daisy = Daisy::new(0x401f85c4 as *mut u32, 0);
+    pub const DAISY_SAI2_TX_SYNC_AD_B0_04: Daisy = Daisy::new(0x401f85c4 as *mut u32, 1);
+    pub const DAISY_SAI3_IPG_CLK_SAI_MCLK_2_EMC_37: Daisy = Daisy::new(0x401f8770 as *mut u32, 0);
+    pub const DAISY_SAI3_IPG_CLK_SAI_MCLK_2_SD_B1_04: Daisy = Daisy::new(0x401f8770 as *mut u32, 1);
+    pub const DAISY_SAI3_IPP_IND_SAI_RXBCLK_EMC_35: Daisy = Daisy::new(0x401f8774 as *mut u32, 0);
+    pub const DAISY_SAI3_IPP_IND_SAI_RXBCLK_SD_B1_06: Daisy = Daisy::new(0x401f8774 as *mut u32, 1);
+    pub const DAISY_SAI3_IPP_IND_SAI_RXDATA_0_EMC_33: Daisy = Daisy::new(0x401f8778 as *mut u32, 0);
+    pub const DAISY_SAI3_IPP_IND_SAI_RXDATA_0_SD_B1_00: Daisy =
+        Daisy::new(0x401f8778 as *mut u32, 1);
+    pub const DAISY_SAI3_IPP_IND_SAI_RXSYNC_EMC_34: Daisy = Daisy::new(0x401f877c as *mut u32, 0);
+    pub const DAISY_SAI3_IPP_IND_SAI_RXSYNC_SD_B1_05: Daisy = Daisy::new(0x401f877c as *mut u32, 1);
+    pub const DAISY_SAI3_IPP_IND_SAI_TXBCLK_EMC_38: Daisy = Daisy::new(0x401f8780 as *mut u32, 0);
+    pub const DAISY_SAI3_IPP_IND_SAI_TXBCLK_SD_B1_03: Daisy = Daisy::new(0x401f8780 as *mut u32, 1);
+    pub const DAISY_SAI3_IPP_IND_SAI_TXSYNC_EMC_39: Daisy = Daisy::new(0x401f8784 as *mut u32, 0);
+    pub const DAISY_SAI3_IPP_IND_SAI_TXSYNC_SD_B1_02: Daisy = Daisy::new(0x401f8784 as *mut u32, 1);
+}
+
+use daisy::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,6 +89,8 @@ pub mod adc;
 mod config;
 pub mod i2c;
 pub mod pwm;
+#[macro_use]
+pub mod sai;
 pub mod spi;
 pub mod uart;
 

--- a/src/sai.rs
+++ b/src/sai.rs
@@ -1,0 +1,128 @@
+//! SAI / I2S pad configurations
+//!
+//! # Examples
+//!
+//! Accept a transfer pin in a SAI driver. Change `TxDataSignal` to `RxDataSignal` for
+//! the inverse operation.
+//!
+//! ```
+//! use imxrt_iomuxc::sai::{Pin, TxDataSignal};
+//! use imxrt_iomuxc::consts::{U1, Unsigned};
+//!
+//! struct SAI<U> {
+//!     /* Driver details... */
+//!     # _u: core::marker::PhantomData<U>,
+//! }
+//!
+//! type SAI1 = SAI<U1>;
+//!
+//! impl<U: Unsigned> SAI<U> {
+//!     fn add_tx_pin<P>(&mut self, pin: P)
+//!     where
+//!         P: Pin<U>,
+//!         <P as Pin<U>>::Signal: TxDataSignal,
+//!     {
+//!         let tx_offset: usize = <P::Signal as TxDataSignal>::Index::to_usize();
+//!         assert_eq!(tx_offset, 1);
+//!         // ...
+//!     }
+//! }
+//!
+//! let mut sai1: SAI1 = // Create SAI1 driver...
+//!     # SAI { _u: core::marker::PhantomData };
+//! let sd_b1_02 = // 1060 SAI1 TX_DATA01 pin...
+//!     # unsafe { imxrt_iomuxc::imxrt1060::sd_b1::SD_B1_02::new() };
+//!
+//!
+//! sai1.add_tx_pin(sd_b1_02);
+//! ```
+
+/// An SAI pin signal
+pub trait Signal: Sealed {}
+/// An SAI TX data signal
+pub trait TxDataSignal: Signal {
+    /// Data pin index; the `3` in `TX_DATA03`
+    type Index: super::consts::Unsigned;
+}
+/// An SAI RX data signal
+pub trait RxDataSignal: Signal {
+    /// Data pin index; the `1` in `RX_DATA01`
+    type Index: super::consts::Unsigned;
+}
+
+pub(crate) mod private {
+    pub trait Sealed {}
+}
+use private::Sealed;
+
+/// A tag that indicates a SAI TX bit clock pad
+pub enum TxBclk {}
+/// A tag that indicates a SAI TX frame sync pad
+pub enum TxSync {}
+/// A tag that indicates a SAI RX bit clock pad
+pub enum RxBclk {}
+/// A tag that indicates a SAI RX frame sync pad
+pub enum RxSync {}
+/// A tag that indicates a SAI MCLK pad
+pub enum Mclk {}
+
+/// A SAI TX data pin
+pub enum TxData {}
+/// A SAI RX data pin
+pub enum RxData {}
+
+impl Signal for TxBclk {}
+impl Signal for TxSync {}
+impl Signal for RxBclk {}
+impl Signal for RxSync {}
+impl Signal for Mclk {}
+
+impl Signal for TxData {}
+impl TxDataSignal for TxData {
+    type Index = super::consts::U0;
+}
+impl Signal for RxData {}
+impl RxDataSignal for RxData {
+    type Index = super::consts::U0;
+}
+
+impl Sealed for TxBclk {}
+impl Sealed for TxSync {}
+impl Sealed for RxBclk {}
+impl Sealed for RxSync {}
+impl Sealed for Mclk {}
+impl Sealed for TxData {}
+impl Sealed for RxData {}
+
+/// A pin that can be used for a SAI peripheral
+///
+/// `SAIx` is a type number, like `U2`, which indicates 'SAI2'.
+pub trait Pin<SAIx: crate::consts::Unsigned>: super::IOMUX {
+    /// The alternate value for the UART pin
+    const ALT: u32;
+    /// The daisy register which will select the pad
+    const DAISY: Option<super::Daisy>;
+    /// The SAI signal
+    type Signal: Signal;
+}
+
+/// Prepare a pad to be used as a SAI pin
+pub fn prepare<SAIx: crate::consts::Unsigned, P: Pin<SAIx>>(pin: &mut P) {
+    super::alternate(pin, P::ALT);
+    super::set_sion(pin);
+    if let Some(daisy) = P::DAISY {
+        unsafe { daisy.write() };
+    }
+}
+
+/// Defines an SAI pin
+#[allow(unused)] // Used in chip-specific modules...
+macro_rules! sai {
+    (module: $m:ty, alt: $alt:expr, pad: $pad:ty, signal: $signal:ty, daisy: $daisy:expr) => {
+        impl Pin<$m> for $pad {
+            const ALT: u32 = $alt;
+            type Signal = $signal;
+            const DAISY: Option<Daisy> = $daisy;
+        }
+    };
+}


### PR DESCRIPTION
This adds traits and impls for the SAI peripherals. (also, it updates the Cargo.toml to point at this repo)

This is very 106x-specific, should I wrap it in a `cfg(feature = "imxrt106x")`? That's the only feature in the crate (on the `v0.1` branch), so I'm not sure. The 1010 I believe does have some (2?) SAI peripherals, and the pads are almost certainly not the same.

SAI3 overlaps on several pins with SAI1, so adding it complains about re-implementing a few traits. There may be a clever way around this (in particular, the traits could be split into separate e.g. `RxSyncPin` and `RxBclkPin` traits), I can do that if we want but I don't feel a pressing need to do so right now. Also the daisy names are different for some reason.

Testing-wise, I've only tested this with SAI1 in one-bit TX mode, with a specific set of pins. I tried to copy the table as closely as possible.
