### PR TITLE
ADC: favor typenum instances, associated constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,22 @@ All notable changes to this project will be documented in this file.
   For rational on this change, see
   [here](https://github.com/imxrt-rs/imxrt-rs/pull/91).
 
+- **BREAKING** in the ADC module, we remove the `ADC` trait. Users should
+  replace usages of `adc::ADC` with `consts::Unsigned`. The `ADC1` and `ADC2`
+  types are now aliases for `U1` and `U2`.
+
+  `adc::Pin::INPUT` is now an associated `u32` constant, not a type. Cast the
+  `u32` as needed for your implementation. See the before and after below for
+  migration tips.
+
+  ```rust
+  // Before
+  let channel: u16 = <P as Pin<ADC1>>::Input::U16;
+
+  // After
+  let channel: u16 = <P as Pin<ADC1>>::INPUT as u16;
+  ```
+
 ### Added
 
 - i.MX RT 1010 support with the `"imxrt1010"` feature:

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -1,28 +1,18 @@
 //! ADC pad configuration
 
-/// An ADC input bank, like `ADC1` and `ADC2`
-pub trait ADC: private::Sealed {}
+use crate::consts::Unsigned;
 
-mod private {
-    pub trait Sealed {}
-    impl Sealed for super::ADC1 {}
-    impl Sealed for super::ADC2 {}
-}
-
-/// Indicates an ADC1-compatible pin
-pub enum ADC1 {}
-impl ADC for ADC1 {}
-
-/// Indicates an ADC2-compatible pin
-pub enum ADC2 {}
-impl ADC for ADC2 {}
+/// Type number for ADC1
+pub type ADC1 = crate::consts::U1;
+/// Type number for ADC2
+pub type ADC2 = crate::consts::U2;
 
 /// Describes an ADC input pin
 ///
 /// ADC pins are specialized GPIO pins. Some pads may be used in both `ADC1`
 /// and `ADC2`, so implementations will indicate their compatibility by
 /// supplying an identifier in place of `ADCx`.
-pub trait Pin<ADCx: ADC>: super::gpio::Pin {
+pub trait Pin<U: Unsigned>: super::gpio::Pin {
     /// The input pin identifier
     ///
     /// Starts at `U0`, and increments up.
@@ -33,7 +23,7 @@ pub trait Pin<ADCx: ADC>: super::gpio::Pin {
 ///
 /// Due to a requirement in the ADC module, `prepare` will disable the pull/keeper
 /// on the pin. The configuration change will not affect any other settings.
-pub fn prepare<ADCx: ADC, P: Pin<ADCx>>(pin: &mut P) {
+pub fn prepare<U: Unsigned, P: Pin<U>>(pin: &mut P) {
     // See the note in the ADC section of the reference manual
     // (using iMXRT1060, rev 2). ADC input signals connect to
     // GPIO, and we need to disable the keeper to prevent signal

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -15,8 +15,8 @@ pub type ADC2 = crate::consts::U2;
 pub trait Pin<U: Unsigned>: super::gpio::Pin {
     /// The input pin identifier
     ///
-    /// Starts at `U0`, and increments up.
-    type Input: super::consts::Unsigned;
+    /// Starts at `0`, and increments up.
+    const INPUT: u32;
 }
 
 /// Prepare an ADC pin

--- a/src/imxrt1060/adc.rs
+++ b/src/imxrt1060/adc.rs
@@ -6,77 +6,74 @@
 //! section of the reference manual.
 
 use super::{ad_b0::*, ad_b1::*};
-use crate::{
-    adc::{Pin, ADC1, ADC2},
-    consts::*,
-};
+use crate::adc::{Pin, ADC1, ADC2};
 
 //
 // ADC1
 //
 
 impl Pin<ADC1> for AD_B1_11 {
-    type Input = U0;
+    const INPUT: u32 = 0;
 }
 
 impl Pin<ADC1> for AD_B0_12 {
-    type Input = U1;
+    const INPUT: u32 = 1;
 }
 
 impl Pin<ADC1> for AD_B0_13 {
-    type Input = U2;
+    const INPUT: u32 = 2;
 }
 
 impl Pin<ADC1> for AD_B0_14 {
-    type Input = U3;
+    const INPUT: u32 = 3;
 }
 
 impl Pin<ADC1> for AD_B0_15 {
-    type Input = U4;
+    const INPUT: u32 = 4;
 }
 
 impl Pin<ADC1> for AD_B1_00 {
-    type Input = U5;
+    const INPUT: u32 = 5;
 }
 
 impl Pin<ADC1> for AD_B1_01 {
-    type Input = U6;
+    const INPUT: u32 = 6;
 }
 
 impl Pin<ADC1> for AD_B1_02 {
-    type Input = U7;
+    const INPUT: u32 = 7;
 }
 
 impl Pin<ADC1> for AD_B1_03 {
-    type Input = U8;
+    const INPUT: u32 = 8;
 }
 
 impl Pin<ADC1> for AD_B1_04 {
-    type Input = U9;
+    const INPUT: u32 = 9;
 }
 
 impl Pin<ADC1> for AD_B1_05 {
-    type Input = U10;
+    const INPUT: u32 = 10;
 }
 
 impl Pin<ADC1> for AD_B1_06 {
-    type Input = U11;
+    const INPUT: u32 = 11;
 }
 
 impl Pin<ADC1> for AD_B1_07 {
-    type Input = U12;
+    const INPUT: u32 = 12;
 }
 
 impl Pin<ADC1> for AD_B1_08 {
-    type Input = U13;
+    const INPUT: u32 = 13;
 }
 
 impl Pin<ADC1> for AD_B1_09 {
-    type Input = U14;
+    const INPUT: u32 = 14;
 }
 
 impl Pin<ADC1> for AD_B1_10 {
-    type Input = U15;
+    const INPUT: u32 = 15;
 }
 
 //
@@ -84,65 +81,65 @@ impl Pin<ADC1> for AD_B1_10 {
 //
 
 impl Pin<ADC2> for AD_B1_11 {
-    type Input = U0;
+    const INPUT: u32 = 0;
 }
 
 impl Pin<ADC2> for AD_B1_12 {
-    type Input = U1;
+    const INPUT: u32 = 1;
 }
 
 impl Pin<ADC2> for AD_B1_13 {
-    type Input = U2;
+    const INPUT: u32 = 2;
 }
 
 impl Pin<ADC2> for AD_B1_14 {
-    type Input = U3;
+    const INPUT: u32 = 3;
 }
 
 impl Pin<ADC2> for AD_B1_15 {
-    type Input = U4;
+    const INPUT: u32 = 4;
 }
 
 impl Pin<ADC2> for AD_B1_00 {
-    type Input = U5;
+    const INPUT: u32 = 5;
 }
 
 impl Pin<ADC2> for AD_B1_01 {
-    type Input = U6;
+    const INPUT: u32 = 6;
 }
 
 impl Pin<ADC2> for AD_B1_02 {
-    type Input = U7;
+    const INPUT: u32 = 7;
 }
 
 impl Pin<ADC2> for AD_B1_03 {
-    type Input = U8;
+    const INPUT: u32 = 8;
 }
 
 impl Pin<ADC2> for AD_B1_04 {
-    type Input = U9;
+    const INPUT: u32 = 9;
 }
 
 impl Pin<ADC2> for AD_B1_05 {
-    type Input = U10;
+    const INPUT: u32 = 10;
 }
 
 impl Pin<ADC2> for AD_B1_06 {
-    type Input = U11;
+    const INPUT: u32 = 11;
 }
 
 impl Pin<ADC2> for AD_B1_07 {
-    type Input = U12;
+    const INPUT: u32 = 12;
 }
 
 impl Pin<ADC2> for AD_B1_08 {
-    type Input = U13;
+    const INPUT: u32 = 13;
 }
 
 impl Pin<ADC2> for AD_B1_09 {
-    type Input = U14;
+    const INPUT: u32 = 14;
 }
 
 impl Pin<ADC2> for AD_B1_10 {
-    type Input = U15;
+    const INPUT: u32 = 15;
 }


### PR DESCRIPTION
The PR favors typenum instance identifiers, instead of the custom types which implement `ADC`. We alias `ADC1` and `ADC2` in terms of typenums to keep the changes minimal.

Favor associated constants, instead of typenum types, for ADC input identifiers. Given the usage in `imxrt-hal`, these are only ever used as runtime constants. Let me know if we're constraining types or APIs based on these associated types.