### PR TITLE
Simplify pull / keeper pad configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,29 @@ All notable changes to this project will be documented in this file.
   - SPI
   - UART
 
+- Unify the pullup, pulldown, and keeper configurations into one enum,
+  `PullKeeper`. This lets you more simply express pin configurations:
+
+  ```rust
+  // Before
+  configure(
+      &mut pad,
+      Config::zero()
+          .set_pull_keep(PullKeep::Enabled)
+          .set_pull_keep_select(PullKeepSelect::Pull)
+          .set_pullupdown(PullUpDown::Pullup100k),
+  );
+
+  // After
+  configure(
+      &mut pad,
+      Config::zero().set_pull_keeper(Some(PullKeeper::Pullup100k))
+  );
+  ```
+
+  This approach will replace the existing API that uses separate methods and
+  enums.
+
 ## [0.1.3] - 2021-04-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,7 @@ All notable changes to this project will be documented in this file.
   ```
 
   This approach will replace the existing API that uses separate methods and
-  enums.
+  enums. All older enums and methods are now deprecated.
 
 ## [0.1.3] - 2021-04-24
 

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -29,10 +29,7 @@ pub fn prepare<U: Unsigned, P: Pin<U>>(pin: &mut P) {
     // GPIO, and we need to disable the keeper to prevent signal
     // jumps.
     super::alternate(pin, <P as super::gpio::Pin>::ALT);
-    super::configure(
-        pin,
-        super::Config::modify().set_pull_keep(super::PullKeep::Disabled),
-    );
+    super::configure(pin, super::Config::modify().set_pull_keeper(None));
 }
 
 #[allow(unused)] // Used in chip-specific modules...

--- a/src/config.rs
+++ b/src/config.rs
@@ -53,6 +53,7 @@ const PULLUPDOWN_MASK: u32 = 0b11 << PULLUPDOWN_SHIFT;
 /// Controls signals to select pull-up or pull-down internal resistance strength.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u32)]
+#[deprecated(since = "0.2.0", note = "Use PullKeeper and Config::set_pull_keeper")]
 pub enum PullUpDown {
     /// 100KOhm pull Down
     Pulldown100k = 0b00 << PULLUPDOWN_SHIFT,
@@ -70,6 +71,7 @@ const PULL_KEEP_SELECT_MASK: u32 = 1 << PULL_KEEP_SELECT_SHIFT;
 /// Control signal to enable internal pull-up/down resistors or pad keeper functionality.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u32)]
+#[deprecated(since = "0.2.0", note = "Use PullKeeper and Config::set_pull_keeper")]
 pub enum PullKeepSelect {
     /// Keep the previous output value when the output driver is disabled.
     Keeper = 0 << PULL_KEEP_SELECT_SHIFT,
@@ -85,6 +87,7 @@ const PULLKEEP_MASK: u32 = 1 << PULLKEEP_SHIFT;
 /// When the pull/keeper is disabled, `PullKeepSelect` and `PullUpDown` have no functionality.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u32)]
+#[deprecated(since = "0.2.0", note = "Use PullKeeper and Config::set_pull_keeper")]
 pub enum PullKeep {
     Enabled = 1 << PULLKEEP_SHIFT,
     Disabled = 0 << PULLKEEP_SHIFT,
@@ -94,6 +97,7 @@ pub enum PullKeep {
 /// the field-specific enums.
 ///
 /// Used to define the public API.
+#[allow(deprecated)]
 const fn pull_keeper(select: PullKeepSelect, pull: Option<PullUpDown>) -> u32 {
     PULLKEEP_MASK
         | (select as u32)
@@ -108,6 +112,7 @@ const PULL_KEEPER_MASK: u32 = PULLKEEP_MASK | PULLUPDOWN_MASK | PULL_KEEP_SELECT
 /// The pull up, pull down, or keeper configuration.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 #[repr(u32)]
+#[allow(deprecated)]
 pub enum PullKeeper {
     /// 100KOhm pull **down**
     Pulldown100k = pull_keeper(PullKeepSelect::Pull, Some(PullUpDown::Pulldown100k)),
@@ -359,6 +364,8 @@ impl Config {
     }
 
     /// Set the pull-up / pull-down value
+    #[deprecated(since = "0.2.0", note = "Use PullKeeper and Config::set_pull_keeper")]
+    #[allow(deprecated)]
     pub const fn set_pullupdown(mut self, pud: PullUpDown) -> Self {
         self.value = (self.value & !PULLUPDOWN_MASK) | (pud as u32);
         self.mask |= PULLUPDOWN_MASK;
@@ -366,6 +373,8 @@ impl Config {
     }
 
     /// Set the the pull-up / pull-down or keeper selection bit
+    #[deprecated(since = "0.2.0", note = "Use PullKeeper and Config::set_pull_keeper")]
+    #[allow(deprecated)]
     pub const fn set_pull_keep_select(mut self, pke: PullKeepSelect) -> Self {
         self.value = (self.value & !PULL_KEEP_SELECT_MASK) | (pke as u32);
         self.mask |= PULL_KEEP_SELECT_MASK;
@@ -373,6 +382,8 @@ impl Config {
     }
 
     /// Set the flag that enables the keeper or pull-up / pull-down configuration
+    #[deprecated(since = "0.2.0", note = "Use PullKeeper and Config::set_pull_keeper")]
+    #[allow(deprecated)]
     pub const fn set_pull_keep(mut self, pk: PullKeep) -> Self {
         self.value = (self.value & !PULLKEEP_MASK) | (pk as u32);
         self.mask |= PULLKEEP_MASK;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,6 +104,7 @@ pub use config::{
     configure, Config, DriveStrength, Hysteresis, OpenDrain, PullKeeper, SlewRate, Speed,
 };
 
+#[allow(deprecated)]
 pub use config::{PullKeep, PullKeepSelect, PullUpDown};
 
 /// Re-export of top-level components, without the chip-specific modules.
@@ -126,6 +127,7 @@ pub mod prelude {
         configure, Config, DriveStrength, Hysteresis, OpenDrain, PullKeeper, SlewRate, Speed,
     };
 
+    #[allow(deprecated)]
     pub use crate::config::{PullKeep, PullKeepSelect, PullUpDown};
 
     pub use crate::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,9 +101,10 @@ pub mod sai;
 use core::ptr;
 
 pub use config::{
-    configure, Config, DriveStrength, Hysteresis, OpenDrain, PullKeep, PullKeepSelect, PullUpDown,
-    SlewRate, Speed,
+    configure, Config, DriveStrength, Hysteresis, OpenDrain, PullKeeper, SlewRate, Speed,
 };
+
+pub use config::{PullKeep, PullKeepSelect, PullUpDown};
 
 /// Re-export of top-level components, without the chip-specific modules.
 ///
@@ -122,9 +123,11 @@ pub use config::{
 /// ```
 pub mod prelude {
     pub use crate::config::{
-        configure, Config, DriveStrength, Hysteresis, OpenDrain, PullKeep, PullKeepSelect,
-        PullUpDown, SlewRate, Speed,
+        configure, Config, DriveStrength, Hysteresis, OpenDrain, PullKeeper, SlewRate, Speed,
     };
+
+    pub use crate::config::{PullKeep, PullKeepSelect, PullUpDown};
+
     pub use crate::{
         consts, flexpwm, gpio, lpi2c, lpspi, lpuart, Daisy, ErasedPad, Pad, WrongPadError,
     };


### PR DESCRIPTION
Users now configure the pull / keeper configuration using a single method and a single enum. It makes it easier to express the pad configuration.

```rust
// Before
configure(
    &mut pad,
    Config::zero()
        .set_pull_keep(PullKeep::Enabled)
        .set_pull_keep_select(PullKeepSelect::Pull)
        .set_pullupdown(PullUpDown::Pullup100k),
);

// After
configure(
    &mut pad,
    Config::zero().set_pull_keeper(Some(PullKeeper::Pullup100k))
);
```

The new API is implemented in terms of the old approach. The old API is still available, and marked as deprecated.

See the unit tests for more examples.