### PR TITLE
Remove old pull / keeper API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- **BREAKING** Remove the deprecated pull / keeper configuration API.
+
 ## [0.2.0] 2022-11-30
 
 ### Changed

--- a/src/config.rs
+++ b/src/config.rs
@@ -51,8 +51,7 @@ const PULLUPDOWN_MASK: u32 = 0b11 << PULLUPDOWN_SHIFT;
 /// Controls signals to select pull-up or pull-down internal resistance strength.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u32)]
-#[deprecated(since = "0.2.0", note = "Use PullKeeper and Config::set_pull_keeper")]
-pub enum PullUpDown {
+enum PullUpDown {
     /// 100KOhm pull Down
     Pulldown100k = 0b00 << PULLUPDOWN_SHIFT,
     /// 47KOhm pull up
@@ -69,8 +68,7 @@ const PULL_KEEP_SELECT_MASK: u32 = 1 << PULL_KEEP_SELECT_SHIFT;
 /// Control signal to enable internal pull-up/down resistors or pad keeper functionality.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u32)]
-#[deprecated(since = "0.2.0", note = "Use PullKeeper and Config::set_pull_keeper")]
-pub enum PullKeepSelect {
+enum PullKeepSelect {
     /// Keep the previous output value when the output driver is disabled.
     Keeper = 0 << PULL_KEEP_SELECT_SHIFT,
     /// Pull-up or pull-down (determined by [`PullUpDown`](struct.PullUpDown.html) flags).
@@ -80,22 +78,10 @@ pub enum PullKeepSelect {
 const PULLKEEP_SHIFT: u32 = 12;
 const PULLKEEP_MASK: u32 = 1 << PULLKEEP_SHIFT;
 
-/// Enable or disable the pull / keeper functionality
-///
-/// When the pull/keeper is disabled, `PullKeepSelect` and `PullUpDown` have no functionality.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[repr(u32)]
-#[deprecated(since = "0.2.0", note = "Use PullKeeper and Config::set_pull_keeper")]
-pub enum PullKeep {
-    Enabled = 1 << PULLKEEP_SHIFT,
-    Disabled = 0 << PULLKEEP_SHIFT,
-}
-
 /// Derives a pull/keep configuration from
 /// the field-specific enums.
 ///
 /// Used to define the public API.
-#[allow(deprecated)]
 const fn pull_keeper(select: PullKeepSelect, pull: Option<PullUpDown>) -> u32 {
     PULLKEEP_MASK
         | (select as u32)
@@ -110,7 +96,6 @@ const PULL_KEEPER_MASK: u32 = PULLKEEP_MASK | PULLUPDOWN_MASK | PULL_KEEP_SELECT
 /// The pull up, pull down, or keeper configuration.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 #[repr(u32)]
-#[allow(deprecated)]
 pub enum PullKeeper {
     /// 100KOhm pull **down**
     Pulldown100k = pull_keeper(PullKeepSelect::Pull, Some(PullUpDown::Pulldown100k)),
@@ -344,33 +329,6 @@ impl Config {
         };
         self.value = (self.value & !PULL_KEEPER_MASK) | (pk as u32);
         self.mask |= PULL_KEEPER_MASK;
-        self
-    }
-
-    /// Set the pull-up / pull-down value
-    #[deprecated(since = "0.2.0", note = "Use PullKeeper and Config::set_pull_keeper")]
-    #[allow(deprecated)]
-    pub const fn set_pullupdown(mut self, pud: PullUpDown) -> Self {
-        self.value = (self.value & !PULLUPDOWN_MASK) | (pud as u32);
-        self.mask |= PULLUPDOWN_MASK;
-        self
-    }
-
-    /// Set the the pull-up / pull-down or keeper selection bit
-    #[deprecated(since = "0.2.0", note = "Use PullKeeper and Config::set_pull_keeper")]
-    #[allow(deprecated)]
-    pub const fn set_pull_keep_select(mut self, pke: PullKeepSelect) -> Self {
-        self.value = (self.value & !PULL_KEEP_SELECT_MASK) | (pke as u32);
-        self.mask |= PULL_KEEP_SELECT_MASK;
-        self
-    }
-
-    /// Set the flag that enables the keeper or pull-up / pull-down configuration
-    #[deprecated(since = "0.2.0", note = "Use PullKeeper and Config::set_pull_keeper")]
-    #[allow(deprecated)]
-    pub const fn set_pull_keep(mut self, pk: PullKeep) -> Self {
-        self.value = (self.value & !PULLKEEP_MASK) | (pk as u32);
-        self.mask |= PULLKEEP_MASK;
         self
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -195,9 +195,6 @@ pub use config::{
     configure, Config, DriveStrength, Hysteresis, OpenDrain, PullKeeper, SlewRate, Speed,
 };
 
-#[allow(deprecated)]
-pub use config::{PullKeep, PullKeepSelect, PullUpDown};
-
 /// Re-export of top-level components, without the chip-specific modules.
 ///
 /// `prelude` is to help HAL implementors re-export the `imxrt-iomuxc` APIs
@@ -217,9 +214,6 @@ pub mod prelude {
     pub use crate::config::{
         configure, Config, DriveStrength, Hysteresis, OpenDrain, PullKeeper, SlewRate, Speed,
     };
-
-    #[allow(deprecated)]
-    pub use crate::config::{PullKeep, PullKeepSelect, PullUpDown};
 
     pub use crate::{
         adc, alternate, ccm, clear_sion, consts, flexpwm, gpio, lpi2c, lpspi, lpuart, sai,


### PR DESCRIPTION
New API is simpler, and provides the same configuration ability as the older API. See #8 for details.