### PR TITLE
Revise Iomuxc trait

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -250,31 +250,25 @@ impl Config {
     ///     Hysteresis, PullKeeper, DriveStrength
     /// };
     ///
-    /// unsafe {
-    ///     // Set a configuration
-    ///     configure(
-    ///         &mut gpio_ad_b0_13,
-    ///         Config::zero()
-    ///             .set_slew_rate(SlewRate::Fast)
-    ///             .set_drive_strength(DriveStrength::R0_7)
-    ///     );
-    ///     assert_eq!(
-    ///         *gpio_ad_b0_13.pad(),
-    ///         DriveStrength::R0_7 as u32 | SlewRate::Fast as u32
-    ///     );
+    /// // Set a configuration
+    /// configure(
+    ///     &mut gpio_ad_b0_13,
+    ///     Config::zero()
+    ///         .set_slew_rate(SlewRate::Fast)
+    ///         .set_drive_strength(DriveStrength::R0_7)
+    /// );
+    /// // DriveStrength::R0_7 as u32 | SlewRate::Fast as u32
     ///
-    ///     // Completely change that configuration
-    ///     configure(
-    ///         &mut gpio_ad_b0_13,
-    ///         Config::zero()
-    ///             .set_hysteresis(Hysteresis::Enabled)
-    ///             .set_pull_keeper(Some(PullKeeper::Pullup22k))
-    ///     );
-    ///     assert_eq!(
-    ///         *gpio_ad_b0_13.pad(),
-    ///         Hysteresis::Enabled as u32 | PullKeeper::Pullup22k as u32
-    ///     );
-    /// }
+    /// // Completely change that configuration
+    /// configure(
+    ///     &mut gpio_ad_b0_13,
+    ///     Config::zero()
+    ///         .set_hysteresis(Hysteresis::Enabled)
+    ///         .set_pull_keeper(Some(PullKeeper::Pullup22k))
+    /// );
+    /// // Hysteresis::Enabled as u32 | PullKeeper::Pullup22k as u32
+    /// //
+    /// // Notice that SlewRate and DriveStrength were set to zero.
     /// ```
     pub const fn zero() -> Self {
         Config {
@@ -292,31 +286,25 @@ impl Config {
     /// # let mut gpio_ad_b0_13 = unsafe { GPIO_AD_B0_13::new() };
     /// use imxrt_iomuxc::{Config, configure, SlewRate, DriveStrength, Hysteresis};
     ///
-    /// unsafe {
-    ///     // Assume a starting value in the register...
-    ///     configure(
-    ///         &mut gpio_ad_b0_13,
-    ///         Config::zero()
-    ///             .set_slew_rate(SlewRate::Fast)
-    ///             .set_drive_strength(DriveStrength::R0_7)
-    ///     );
-    ///     assert_eq!(
-    ///         *gpio_ad_b0_13.pad(),
-    ///         DriveStrength::R0_7 as u32 | SlewRate::Fast as u32
-    ///     );
+    /// // Assume a starting value in the register...
+    /// configure(
+    ///     &mut gpio_ad_b0_13,
+    ///     Config::zero()
+    ///         .set_slew_rate(SlewRate::Fast)
+    ///         .set_drive_strength(DriveStrength::R0_7)
+    /// );
+    /// // DriveStrength::R0_7 as u32 | SlewRate::Fast as u32
     ///
-    ///     // Now change the slew rate, and add hysteresis
-    ///     configure(
-    ///         &mut gpio_ad_b0_13,
-    ///         Config::modify()
-    ///             .set_slew_rate(SlewRate::Slow)
-    ///             .set_hysteresis(Hysteresis::Enabled)
-    ///     );
-    ///     assert_eq!(
-    ///         *gpio_ad_b0_13.pad(),
-    ///         DriveStrength::R0_7 as u32 | Hysteresis::Enabled as u32
-    ///     );
-    /// }
+    /// // Now change the slew rate, and add hysteresis
+    /// configure(
+    ///     &mut gpio_ad_b0_13,
+    ///     Config::modify()
+    ///         .set_slew_rate(SlewRate::Slow)
+    ///         .set_hysteresis(Hysteresis::Enabled)
+    /// );
+    /// // DriveStrength::R0_7 as u32 | Hysteresis::Enabled as u32
+    /// //
+    /// // Notice that the DriveStrength field is preserved.
     /// ```
     pub const fn modify() -> Self {
         Config {

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,7 +15,7 @@ use core::ptr;
 /// use imxrt_iomuxc::{configure, Config, OpenDrain, PullKeeper};
 /// # use imxrt_iomuxc::Iomuxc;; #[allow(non_camel_case_types)] pub struct GPIO_AD_B0_03;
 /// # impl GPIO_AD_B0_03 { unsafe fn new() -> Self { Self } fn ptr(&self) -> *mut u32 { core::ptr::null_mut() }}
-/// # unsafe impl Iomuxc for GPIO_AD_B0_03 { unsafe fn mux(&mut self) -> *mut u32 { self.ptr() } unsafe fn pad(&mut self) -> *mut u32 { self.ptr() }}
+/// # unsafe impl Iomuxc for GPIO_AD_B0_03 { fn mux(&mut self) -> *mut u32 { self.ptr() } fn pad(&mut self) -> *mut u32 { self.ptr() }}
 ///
 /// const CONFIG: Config = Config::zero()
 ///     .set_open_drain(OpenDrain::Enabled)
@@ -246,7 +246,7 @@ impl Config {
     ///
     /// ```
     /// # use imxrt_iomuxc::Iomuxc;
-    /// # struct Pad(u32); unsafe impl Iomuxc for Pad { unsafe fn mux(&mut self) -> *mut u32 { panic!() } unsafe fn pad(&mut self) -> *mut u32 { &mut self.0 as *mut _} }
+    /// # struct Pad(u32); unsafe impl Iomuxc for Pad { fn mux(&mut self) -> *mut u32 { panic!() } fn pad(&mut self) -> *mut u32 { &mut self.0 as *mut _} }
     /// # let mut gpio_ad_b0_13 = Pad(0xFFFF_FFFFu32);
     /// use imxrt_iomuxc::{
     ///     Config, configure, SlewRate,
@@ -292,7 +292,7 @@ impl Config {
     ///
     /// ```
     /// # use imxrt_iomuxc::Iomuxc;
-    /// # struct Pad(u32); unsafe impl Iomuxc for Pad { unsafe fn mux(&mut self) -> *mut u32 { panic!() } unsafe fn pad(&mut self) -> *mut u32 { &mut self.0 as *mut _} }
+    /// # struct Pad(u32); unsafe impl Iomuxc for Pad { fn mux(&mut self) -> *mut u32 { panic!() } fn pad(&mut self) -> *mut u32 { &mut self.0 as *mut _} }
     /// # let mut gpio_ad_b0_13 = Pad(0xFFFF_FFFFu32);
     /// use imxrt_iomuxc::{Config, configure, SlewRate, DriveStrength, Hysteresis};
     ///
@@ -432,10 +432,10 @@ mod tests {
     const PAD_BITMASK: u32 = 0b1_1111_1000_1111_1001u32;
 
     unsafe impl Iomuxc for Pad {
-        unsafe fn mux(&mut self) -> *mut u32 {
+        fn mux(&mut self) -> *mut u32 {
             panic!("Nothing calls mux() in these tests");
         }
-        unsafe fn pad(&mut self) -> *mut u32 {
+        fn pad(&mut self) -> *mut u32 {
             &mut self.0 as *mut _
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,9 +13,7 @@ use core::ptr;
 ///
 /// ```no_run
 /// use imxrt_iomuxc::{configure, Config, OpenDrain, PullKeeper};
-/// # use imxrt_iomuxc::Iomuxc;; #[allow(non_camel_case_types)] pub struct GPIO_AD_B0_03;
-/// # impl GPIO_AD_B0_03 { unsafe fn new() -> Self { Self } fn ptr(&self) -> *mut u32 { core::ptr::null_mut() }}
-/// # unsafe impl Iomuxc for GPIO_AD_B0_03 { fn mux(&mut self) -> *mut u32 { self.ptr() } fn pad(&mut self) -> *mut u32 { self.ptr() }}
+/// # use imxrt_iomuxc::imxrt1060::gpio_ad_b0::GPIO_AD_B0_03;
 ///
 /// const CONFIG: Config = Config::zero()
 ///     .set_open_drain(OpenDrain::Enabled)
@@ -244,10 +242,9 @@ impl Config {
     /// created using `zero()` will have the effect of writing *all* fields
     /// to the register. Those that are not set explicitly set are written as zero.
     ///
-    /// ```
-    /// # use imxrt_iomuxc::Iomuxc;
-    /// # struct Pad(u32); unsafe impl Iomuxc for Pad { fn mux(&mut self) -> *mut u32 { panic!() } fn pad(&mut self) -> *mut u32 { &mut self.0 as *mut _} }
-    /// # let mut gpio_ad_b0_13 = Pad(0xFFFF_FFFFu32);
+    /// ```no_run
+    /// # use imxrt_iomuxc::{Iomuxc, imxrt1060::gpio_ad_b0::GPIO_AD_B0_13};
+    /// # let mut gpio_ad_b0_13 = unsafe { GPIO_AD_B0_13::new() };
     /// use imxrt_iomuxc::{
     ///     Config, configure, SlewRate,
     ///     Hysteresis, PullKeeper, DriveStrength
@@ -290,10 +287,9 @@ impl Config {
     ///
     /// Any field that is is *not* specified in the configuration will not be touched.
     ///
-    /// ```
-    /// # use imxrt_iomuxc::Iomuxc;
-    /// # struct Pad(u32); unsafe impl Iomuxc for Pad { fn mux(&mut self) -> *mut u32 { panic!() } fn pad(&mut self) -> *mut u32 { &mut self.0 as *mut _} }
-    /// # let mut gpio_ad_b0_13 = Pad(0xFFFF_FFFFu32);
+    /// ```no_run
+    /// # use imxrt_iomuxc::{Iomuxc, imxrt1060::gpio_ad_b0::GPIO_AD_B0_13};
+    /// # let mut gpio_ad_b0_13 = unsafe { GPIO_AD_B0_13::new() };
     /// use imxrt_iomuxc::{Config, configure, SlewRate, DriveStrength, Hysteresis};
     ///
     /// unsafe {
@@ -430,6 +426,8 @@ mod tests {
 
     /// The high bits represent the valid fields in pad registers.
     const PAD_BITMASK: u32 = 0b1_1111_1000_1111_1001u32;
+
+    impl crate::private::Sealed for Pad {}
 
     unsafe impl Iomuxc for Pad {
         fn mux(&mut self) -> *mut u32 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,8 +47,8 @@
 //!         # UART
 //!     }
 //! }
-//! # struct GPIO_AD_B0_03; impl GPIO_AD_B0_03 { unsafe fn new() -> Self { Self } fn erase(self) -> ErasedPad { unimplemented!() }} unsafe impl imxrt_iomuxc::Iomuxc for GPIO_AD_B0_03 { unsafe fn mux(&mut self) -> *mut u32 { panic!() } unsafe fn pad(&mut self) -> *mut u32 { panic!() } }
-//! # struct GPIO_AD_B0_04; impl GPIO_AD_B0_04 { unsafe fn new() -> Self { Self } fn erase(self) -> ErasedPad { unimplemented!() }} unsafe impl imxrt_iomuxc::Iomuxc for GPIO_AD_B0_04 { unsafe fn mux(&mut self) -> *mut u32 { panic!() } unsafe fn pad(&mut self) -> *mut u32 { panic!() } }
+//! # struct GPIO_AD_B0_03; impl GPIO_AD_B0_03 { unsafe fn new() -> Self { Self } fn erase(self) -> ErasedPad { unimplemented!() }} unsafe impl imxrt_iomuxc::Iomuxc for GPIO_AD_B0_03 { fn mux(&mut self) -> *mut u32 { panic!() } fn pad(&mut self) -> *mut u32 { panic!() } }
+//! # struct GPIO_AD_B0_04; impl GPIO_AD_B0_04 { unsafe fn new() -> Self { Self } fn erase(self) -> ErasedPad { unimplemented!() }} unsafe impl imxrt_iomuxc::Iomuxc for GPIO_AD_B0_04 { fn mux(&mut self) -> *mut u32 { panic!() } fn pad(&mut self) -> *mut u32 { panic!() } }
 //! # impl imxrt_iomuxc::lpuart::Pin for GPIO_AD_B0_03 { const ALT: u32 = 0; type Direction = imxrt_iomuxc::lpuart::Tx; type Module = imxrt_iomuxc::consts::U1; const DAISY: Option<imxrt_iomuxc::Daisy> = None; }
 //! # impl imxrt_iomuxc::lpuart::Pin for GPIO_AD_B0_04 { const ALT: u32 = 0; type Direction = imxrt_iomuxc::lpuart::Rx; type Module = imxrt_iomuxc::consts::U1; const DAISY: Option<imxrt_iomuxc::Daisy> = None; }
 //!
@@ -218,18 +218,10 @@ pub mod imxrt1060;
 /// **DO NOT IMPLEMENT THIS TRAIT**. It's exposed to support documentation
 /// browsing.
 pub unsafe trait Iomuxc {
-    /// Returns the absolute address of the multiplex register
-    ///
-    /// # Safety
-    ///
-    /// Returns a pointer to an address that may be mutably aliased elsewhere.
-    unsafe fn mux(&mut self) -> *mut u32;
-    /// Returns the absolute address of the pad configuration register
-    ///
-    /// # Safety
-    ///
-    /// Returns a pointer to an address that may be mutably aliased elsewhere.
-    unsafe fn pad(&mut self) -> *mut u32;
+    /// Returns the absolute address of the multiplex register.
+    fn mux(&mut self) -> *mut u32;
+    /// Returns the absolute address of the pad configuration register.
+    fn pad(&mut self) -> *mut u32;
 }
 
 const SION_BIT: u32 = 1 << 4;
@@ -424,20 +416,14 @@ where
     Base: crate::Base,
     Offset: crate::consts::Unsigned,
 {
-    /// # Safety
-    ///
-    /// Returns a pointer to an address that may be mutably aliased elsewhere.
     #[inline(always)]
-    unsafe fn mux(&mut self) -> *mut u32 {
-        Base::mux_base().add(Offset::USIZE)
+    fn mux(&mut self) -> *mut u32 {
+        (Base::mux_base() as usize + 4 * Offset::USIZE) as *mut u32
     }
 
-    /// # Safety
-    ///
-    /// Returns a pointer to an address that may be mutably aliased elsewhere.
     #[inline(always)]
-    unsafe fn pad(&mut self) -> *mut u32 {
-        Base::pad_base().add(Offset::USIZE)
+    fn pad(&mut self) -> *mut u32 {
+        (Base::pad_base() as usize + 4 * Offset::USIZE) as *mut u32
     }
 }
 
@@ -473,20 +459,14 @@ pub struct ErasedPad {
 }
 
 unsafe impl crate::Iomuxc for ErasedPad {
-    /// # Safety
-    ///
-    /// Returns a pointer to an address that may be mutably aliased elsewhere.
     #[inline(always)]
-    unsafe fn mux(&mut self) -> *mut u32 {
-        self.mux_base.add(self.offset)
+    fn mux(&mut self) -> *mut u32 {
+        (self.mux_base as usize + 4 * self.offset) as *mut u32
     }
 
-    /// # Safety
-    ///
-    /// Returns a pointer to an address that may be mutably aliased elsewhere.
     #[inline(always)]
-    unsafe fn pad(&mut self) -> *mut u32 {
-        self.pad_base.add(self.offset)
+    fn pad(&mut self) -> *mut u32 {
+        (self.pad_base as usize + 4 * self.offset) as *mut u32
     }
 }
 
@@ -555,7 +535,7 @@ impl Daisy {
 /// ```
 /// # use imxrt_iomuxc::Iomuxc; #[allow(non_camel_case_types)] pub struct GPIO_AD_B0_03;
 /// # impl GPIO_AD_B0_03 { unsafe fn new() -> Self { Self } fn ptr(&self) -> *mut u32 { core::ptr::null_mut() }}
-/// # unsafe impl Iomuxc for GPIO_AD_B0_03 { unsafe fn mux(&mut self) -> *mut u32 { self.ptr() } unsafe fn pad(&mut self) -> *mut u32 { self.ptr() }}
+/// # unsafe impl Iomuxc for GPIO_AD_B0_03 { fn mux(&mut self) -> *mut u32 { self.ptr() } fn pad(&mut self) -> *mut u32 { self.ptr() }}
 /// ```
 #[cfg(doctest)]
 pub struct DocPadSnippet;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -212,12 +212,16 @@ pub mod imxrt1060;
 
 /// An IOMUXC-capable pad which can support I/O multiplexing
 ///
-/// **DO NOT IMPLEMENT THIS TRAIT**. It's exposed to support documentation
-/// browsing.
+/// # Safety
+///
+/// This should only be implemented on types that return pointers to static
+/// memory.
 pub unsafe trait Iomuxc: private::Sealed {
     /// Returns the absolute address of the multiplex register.
+    #[doc(hidden)]
     fn mux(&mut self) -> *mut u32;
     /// Returns the absolute address of the pad configuration register.
+    #[doc(hidden)]
     fn pad(&mut self) -> *mut u32;
 }
 


### PR DESCRIPTION
Seal the `Iomuxc` trait, so we're the only implementations. The trait is still unsafe to implement. The new docs describe how to ensure a safe implementation, and also resolve a new clippy warning.

`mux` and `pad` methods are safe to call. Since the pointers are expected to point to static memory, there's no lifetime issues. Hide these two methods to signals that they should not be used outside of this crate.