### PR TITLE
Test 1010, 1060 pad boundaries

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -17,9 +17,9 @@ fn main() -> io::Result<()> {
 fn imxrt1010<W: io::Write>(mut pads_rs: W) -> io::Result<()> {
     use imxrt_iomuxc_build as build;
 
-    let gpio_ad = build::PadRange::new("GPIO_AD", 0..16);
-    let gpio_sd = build::PadRange::new("GPIO_SD", 0..16);
-    let gpio = build::PadRange::new("GPIO", 0..16);
+    let gpio_ad = build::PadRange::new("GPIO_AD", 0..15);
+    let gpio_sd = build::PadRange::new("GPIO_SD", 0..15);
+    let gpio = build::PadRange::new("GPIO", 0..14);
 
     build::write_pads(&mut pads_rs, vec![&gpio_ad, &gpio_sd, &gpio])?;
     build::write_impl_gpio_pins(

--- a/tests/imxrt1010.rs
+++ b/tests/imxrt1010.rs
@@ -1,0 +1,21 @@
+//! Smoke tests for the 1010 pads.
+
+#![cfg(feature = "imxrt1010")]
+
+#[macro_use]
+mod macros;
+
+use imxrt_iomuxc::imxrt1010 as pads;
+
+group!(gpio_ad, 15,
+         [GPIO_AD_14, GPIO_AD_00],
+    mux: [0x401F_8010, 0x401F_8048],
+    pad: [0x401F_80C0, 0x401F_80F8]);
+group!(gpio_sd, 15,
+         [GPIO_SD_14, GPIO_SD_00],
+    mux: [0x401F_804C, 0x401F_8084],
+    pad: [0x401F_80FC, 0x401F_8134]);
+group!(gpio, 14,
+         [GPIO_13, GPIO_00],
+    mux: [0x401F_8088, 0x401F_80BC],
+    pad: [0x401F_8138, 0x401F_816C]);

--- a/tests/imxrt1060.rs
+++ b/tests/imxrt1060.rs
@@ -1,0 +1,37 @@
+//! Smoke tests for 1060 pads.
+
+#![cfg(feature = "imxrt1060")]
+
+#[macro_use]
+mod macros;
+
+use imxrt_iomuxc::imxrt1060 as pads;
+
+group!(gpio_emc, 42,
+         [GPIO_EMC_00, GPIO_EMC_41],
+    mux: [0x401F_8014, 0x401F_80B8],
+    pad: [0x401F_8204, 0x401F_82A8]);
+group!(gpio_ad_b0, 16,
+         [GPIO_AD_B0_00, GPIO_AD_B0_15],
+    mux: [0x401F_80BC, 0x401F_80F8],
+    pad: [0x401F_82AC, 0x401F_82E8]);
+group!(gpio_ad_b1, 16,
+         [GPIO_AD_B1_00, GPIO_AD_B1_15],
+    mux: [0x401F_80FC, 0x401F_8138],
+    pad: [0x401F_82EC, 0x401F_8328]);
+group!(gpio_b0, 16,
+         [GPIO_B0_00, GPIO_B0_15],
+    mux: [0x401F_813C, 0x401F_8178],
+    pad: [0x401F_832C, 0x401F_8368]);
+group!(gpio_b1, 16,
+         [GPIO_B1_00, GPIO_B1_15],
+    mux: [0x401F_817C, 0x401F_81B8],
+    pad: [0x401F_836C, 0x401F_83A8]);
+group!(gpio_sd_b0, 06,
+         [GPIO_SD_B0_00, GPIO_SD_B0_05],
+    mux: [0x401F_81BC, 0x401F_81D0],
+    pad: [0x401F_83AC, 0x401F_83C0]);
+group!(gpio_sd_b1, 12,
+         [GPIO_SD_B1_00, GPIO_SD_B1_11],
+    mux: [0x401F_81D4, 0x401F_8200],
+    pad: [0x401F_83C4, 0x401F_83F0]);

--- a/tests/macros/mod.rs
+++ b/tests/macros/mod.rs
@@ -1,0 +1,34 @@
+//! Macros shared across test suites.
+
+/// Checks the bounds of a group.
+macro_rules! group {
+    ($group: ident, $count: expr,
+        [ $id_left: ident, $id_right: ident ],
+        mux: [ $mux_left: expr, $mux_right: expr ],
+        pad: [ $pad_left: expr, $pad_right: expr ]) => {
+        mod $group {
+            use super::pads;
+            use imxrt_iomuxc::Iomuxc;
+
+            #[test]
+            #[ignore]
+            fn erased_pad_count() {
+                let erased = unsafe { pads::$group::Pads::new().erase() };
+                assert_eq!(erased.len(), $count);
+            }
+
+            #[test]
+            #[ignore]
+            fn pad_bounds() {
+                let mut left = unsafe { pads::$group::$id_left::new() };
+                let mut right = unsafe { pads::$group::$id_right::new() };
+
+                assert_eq!(left.mux() as u32, $mux_left);
+                assert_eq!(right.mux() as u32, $mux_right);
+
+                assert_eq!(left.pad() as u32, $pad_left);
+                assert_eq!(right.pad() as u32, $pad_right);
+            }
+        }
+    };
+}


### PR DESCRIPTION
The tests assert that the pads at each end of a group return the proper MUX and PAD register addresses. They compile, but are temporarily marked as `#[ignore]`, since they demonstrate #11. Run them locally to produce the issue:

```
cargo test --all-features -- --ignored
```

The PR also corrects the number of pads generated on the 1010. This fix allows some of the 1010 tests to pass.

This PR is the base of a larger refactor to fix 11. In subsequent PRs, I remove `#[ignore]`. Having these in place just for compile coverage is helpful.