### PR TITLE
Define pads with absolute register addresses

### DIFF
--- a/imxrt-iomuxc-build/src/lib.rs
+++ b/imxrt-iomuxc-build/src/lib.rs
@@ -145,10 +145,12 @@ where
             .zip(range.range.clone())
             .map(|(base, n)| {
                 let name = quote::format_ident!("{}_{:02}", base, n);
-                let unsigned = quote::format_ident!("U{}", n);
                 let base = quote::format_ident!("{}", base);
+                let n = n as u32;
+                let mux = quote::quote! { { #base::MUX + (4 * #n) } };
+                let pad = quote::quote! { { #base::PAD + (4 * #n) } };
                 quote::quote! {
-                    pub type #name = Pad<#base, #unsigned>;
+                    pub type #name = Pad<#mux, #pad>;
                 }
             });
         let pad_members = std::iter::repeat(range.base.clone())
@@ -181,8 +183,9 @@ where
         let erased_doc = format!("Erased pads with the prefix '{}'", range.base);
         quote::quote! {
             #[doc = #doc]
+            #[allow(clippy::identity_op, clippy::erasing_op)]
             pub mod #name {
-                use crate::{ErasedPad, Pad, consts::*};
+                use crate::{ErasedPad, Pad};
                 use super::super::bases::*;
                 #(#types)*
 

--- a/imxrt-iomuxc-build/tests/write_pads.rs
+++ b/imxrt-iomuxc-build/tests/write_pads.rs
@@ -11,12 +11,13 @@ fn test_write_pads() {
             #![allow(non_camel_case_types)] // Conform with reference manual
 
             #[doc = "Pads with the prefix 'FOO'"]
+            #[allow(clippy::identity_op, clippy::erasing_op)]
             pub mod foo {
-                use crate::{ErasedPad, Pad, consts::*};
+                use crate::{ErasedPad, Pad};
                 use super::super::bases::*;
 
-                pub type FOO_02 = Pad<FOO, U2>;
-                pub type FOO_03 = Pad<FOO, U3>;
+                pub type FOO_02 = Pad<{ FOO::MUX + (4 * 2u32) }, { FOO::PAD + (4 * 2u32) }>;
+                pub type FOO_03 = Pad<{ FOO::MUX + (4 * 3u32) }, { FOO::PAD + (4 * 3u32) }>;
 
                 #[doc = "Pads with the prefix 'FOO'"]
                 pub struct Pads {
@@ -63,12 +64,13 @@ fn test_write_pads() {
             }
 
             #[doc = "Pads with the prefix 'BAR'"]
+            #[allow(clippy::identity_op, clippy::erasing_op)]
             pub mod bar {
-                use crate::{ErasedPad, Pad, consts::*};
+                use crate::{ErasedPad, Pad};
                 use super::super::bases::*;
 
-                pub type BAR_37 = Pad<BAR, U37>;
-                pub type BAR_38 = Pad<BAR, U38>;
+                pub type BAR_37 = Pad<{ BAR::MUX + (4 * 37u32) }, { BAR::PAD + (4 * 37u32) }>;
+                pub type BAR_38 = Pad<{ BAR::MUX + (4 * 38u32) }, { BAR::PAD + (4 * 38u32) }>;
 
                 #[doc = "Pads with the prefix 'BAR'"]
                 pub struct Pads {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -309,7 +309,7 @@ unsafe impl<const MUX: u32, const PAD: u32> Send for Pad<MUX, PAD> {}
 impl<const MUX: u32, const PAD: u32> Pad<MUX, PAD> {
     /// Erase the pad's type, returning an `ErasedPad`
     #[inline(always)]
-    pub fn erase(self) -> ErasedPad {
+    pub const fn erase(self) -> ErasedPad {
         ErasedPad {
             mux: Self::mux(),
             pad: Self::pad(),


### PR DESCRIPTION
We used to describe a pad with

- two absolute addresses to the start of the MUX and PAD group, collectively called a "base"
- an offset into the group block

We did this with custom types and typenums. The pad types are unique, because the (base, offset) type pairings are unique. But, there's the chance for a runtime op to compute a pointer offset. And when erasing the types, we need to maintain three pieces of information: two pointers for the base, and one offset.

In this PR, we use const generics to describe absolute MUX and PAD register addresses in `Pad` types. The types are still unique, since the absolute addresses are unique. There's less chance for a runtime cost for pointer offset, and we can reduce the size of all erased pads by four bytes.

Use tests from #21 and the doctests to show that most documented APIs are unchanged. Note that this PR targets #21's branch.