### PR TITLE
Support Non-zero Chip Selects for lpspi4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target/
 Cargo.lock
 .vscode/
 *.hex
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- **BREAKING** Add support for additional chip select pins for `lpspi4`.
+
 - **BREAKING** Remove the deprecated pull / keeper configuration API.
 
 - **BREAKING** Change the type of the `lpspi::Pins::DAISY` associated constant

--- a/src/imxrt1060/lpspi.rs
+++ b/src/imxrt1060/lpspi.rs
@@ -5,7 +5,7 @@ use super::pads::{
 };
 use crate::{
     consts::*,
-    lpspi::{Pcs0, Pin, Sck, Sdi, Sdo},
+    lpspi::{Pcs0, Pcs1, Pcs2, Pcs3, Pin, Sck, Sdi, Sdo},
     Daisy,
 };
 
@@ -56,6 +56,9 @@ spi!(module: U4, alt: 1, pad: GPIO_B1_05, signal: Sdi,  daisy: Some(DAISY_LPSPI4
 spi!(module: U4, alt: 3, pad: GPIO_B0_01, signal: Sdi,  daisy: Some(DAISY_LPSPI4_SDI_GPIO_B0_01));
 spi!(module: U4, alt: 1, pad: GPIO_B1_04, signal: Pcs0, daisy: Some(DAISY_LPSPI4_PCS0_GPIO_B1_04));
 spi!(module: U4, alt: 3, pad: GPIO_B0_00, signal: Pcs0, daisy: Some(DAISY_LPSPI4_PCS0_GPIO_B0_00));
+spi!(module: U4, alt: 2, pad: GPIO_B1_03, signal: Pcs1, daisy: None);
+spi!(module: U4, alt: 2, pad: GPIO_B1_02, signal: Pcs2, daisy: None);
+spi!(module: U4, alt: 6, pad: GPIO_B1_11, signal: Pcs3, daisy: None);
 
 /// Auto-generated DAISY values
 mod daisy {

--- a/src/lpspi.rs
+++ b/src/lpspi.rs
@@ -9,13 +9,22 @@ pub enum Sck {}
 pub enum Sdo {}
 /// A tag that indicates a SPI data in pad
 pub enum Sdi {}
-/// A tag that indicates a SPI chip select pad
+/// A tag that indicates the Pcs0 chip select pad
 pub enum Pcs0 {}
+/// A tag that indicates the Pcs1 chip select pad
+pub enum Pcs1 {}
+/// A tag that indicates the Pcs2 chip select pad
+pub enum Pcs2 {}
+/// A tag that indicates the Pcs3 chip select pad
+pub enum Pcs3 {}
 
 impl Signal for Sck {}
 impl Signal for Sdo {}
 impl Signal for Sdi {}
 impl Signal for Pcs0 {}
+impl Signal for Pcs1 {}
+impl Signal for Pcs2 {}
+impl Signal for Pcs3 {}
 
 mod private {
     pub trait Sealed {}
@@ -23,6 +32,9 @@ mod private {
     impl Sealed for super::Sdo {}
     impl Sealed for super::Sdi {}
     impl Sealed for super::Pcs0 {}
+    impl Sealed for super::Pcs1 {}
+    impl Sealed for super::Pcs2 {}
+    impl Sealed for super::Pcs3 {}
 }
 
 /// A SPI pin


### PR DESCRIPTION
Add pins for `lpspi4 Pcs[1-3]`, with their corresponding tags.

This is the first portion of the work needed to support multiple peripherals on a single SPI bus. Changes in this PR only affect imxrt1060-series microcontrollers.