### PR TITLE
Favor optional LPI2C daisies; add FlexPWM daisies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ All notable changes to this project will be documented in this file.
 
 - **BREAKING** Remove the deprecated pull / keeper configuration API.
 
-- **BREAKING** Change the type of the `lpspi::Pins::DAISY` associated constant
-  to an `Option<Daisy>`.
+- **BREAKING** Change the type of the `lpspi::Pin::DAISY` and `lpi2c::Pin::DAISY`
+  associated constant to an `Option<Daisy>`.
 
 ## [0.2.1] 2023-02-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ All notable changes to this project will be documented in this file.
 - **BREAKING** Change the type of the `lpspi::Pin::DAISY` and `lpi2c::Pin::DAISY`
   associated constant to an `Option<Daisy>`.
 
+- Add optional `DAISY` associated constant to `flexpwm::Pin`.
+
 ## [0.2.1] 2023-02-23
 
 - Add FlexCAN pin trait with implementations for select 1060 pads.

--- a/src/flexpwm.rs
+++ b/src/flexpwm.rs
@@ -22,6 +22,8 @@ pub trait Pin: super::Iomuxc {
     const ALT: u32;
     /// The output identifier
     type Output: Output;
+    /// The daisy register which will select the pad
+    const DAISY: Option<super::Daisy>;
     /// The PWM module; `U2` is `PWM2`
     type Module: super::consts::Unsigned;
     /// The PWM submodule; `U3` for `PWM2_SM3`
@@ -35,14 +37,18 @@ pub trait Pin: super::Iomuxc {
 /// `prepare()` inherits all the unsafety of the `IOMUX` supertrait.
 pub fn prepare<P: Pin>(pin: &mut P) {
     super::alternate(pin, P::ALT);
+    if let Some(daisy) = P::DAISY {
+        unsafe { daisy.write() };
+    }
 }
 
 #[allow(unused)] // Used in chip-specific modules...
 macro_rules! pwm {
-    (module: $module:ty, submodule: $submodule:ty, alt: $alt:expr, pad: $pad:ty, output: $output:ty) => {
+    (module: $module:ty, submodule: $submodule:ty, alt: $alt:expr, pad: $pad:ty, output: $output:ty, daisy: $daisy:expr) => {
         impl Pin for $pad {
             const ALT: u32 = $alt;
             type Output = $output;
+            const DAISY: Option<Daisy> = $daisy;
             type Module = $module;
             type Submodule = $submodule;
         }

--- a/src/imxrt1010/flexpwm.rs
+++ b/src/imxrt1010/flexpwm.rs
@@ -7,22 +7,46 @@ use super::pads::{gpio::*, gpio_ad::*, gpio_sd::*};
 use crate::{
     consts::*,
     flexpwm::{Pin, A, B},
+    Daisy,
 };
 
-pwm!(module: U0, submodule: U0, alt: 2, pad: GPIO_SD_02, output: A);
-pwm!(module: U0, submodule: U0, alt: 2, pad: GPIO_02, output: A);
-pwm!(module: U0, submodule: U1, alt: 2, pad: GPIO_SD_04, output: A);
-pwm!(module: U0, submodule: U1, alt: 2, pad: GPIO_04, output: A);
-pwm!(module: U0, submodule: U2, alt: 2, pad: GPIO_AD_04, output: A);
-pwm!(module: U0, submodule: U2, alt: 2, pad: GPIO_06, output: A);
-pwm!(module: U0, submodule: U3, alt: 2, pad: GPIO_AD_06, output: A);
-pwm!(module: U0, submodule: U3, alt: 2, pad: GPIO_08, output: A);
+pwm!(module: U0, submodule: U0, alt: 2, pad: GPIO_SD_02, output: A, daisy: Some(DAISY_FLEXPWM0_PWMA0_GPIO_SD_02));
+pwm!(module: U0, submodule: U0, alt: 2, pad: GPIO_02, output: A, daisy: Some(DAISY_FLEXPWM0_PWMA0_GPIO_02));
+pwm!(module: U0, submodule: U1, alt: 2, pad: GPIO_SD_04, output: A, daisy: Some(DAISY_FLEXPWM0_PWMA1_GPIO_SD_04));
+pwm!(module: U0, submodule: U1, alt: 2, pad: GPIO_04, output: A, daisy: Some(DAISY_FLEXPWM0_PWMA1_GPIO_04));
+pwm!(module: U0, submodule: U2, alt: 2, pad: GPIO_AD_04, output: A, daisy: Some(DAISY_FLEXPWM0_PWMA2_GPIO_AD_04));
+pwm!(module: U0, submodule: U2, alt: 2, pad: GPIO_06, output: A, daisy: Some(DAISY_FLEXPWM0_PWMA2_GPIO_06));
+pwm!(module: U0, submodule: U3, alt: 2, pad: GPIO_AD_06, output: A, daisy: Some(DAISY_FLEXPWM0_PWMA3_GPIO_AD_06));
+pwm!(module: U0, submodule: U3, alt: 2, pad: GPIO_08, output: A, daisy: Some(DAISY_FLEXPWM0_PWMA3_GPIO_08));
 
-pwm!(module: U0, submodule: U0, alt: 2, pad: GPIO_SD_01, output: B);
-pwm!(module: U0, submodule: U0, alt: 2, pad: GPIO_01, output: B);
-pwm!(module: U0, submodule: U1, alt: 2, pad: GPIO_SD_03, output: B);
-pwm!(module: U0, submodule: U1, alt: 2, pad: GPIO_03, output: B);
-pwm!(module: U0, submodule: U2, alt: 2, pad: GPIO_AD_03, output: B);
-pwm!(module: U0, submodule: U2, alt: 2, pad: GPIO_05, output: B);
-pwm!(module: U0, submodule: U3, alt: 2, pad: GPIO_AD_05, output: B);
-pwm!(module: U0, submodule: U3, alt: 2, pad: GPIO_07, output: B);
+pwm!(module: U0, submodule: U0, alt: 2, pad: GPIO_SD_01, output: B, daisy: Some(DAISY_FLEXPWM0_PWMB0_GPIO_SD_01));
+pwm!(module: U0, submodule: U0, alt: 2, pad: GPIO_01, output: B, daisy: Some(DAISY_FLEXPWM0_PWMB0_GPIO_01));
+pwm!(module: U0, submodule: U1, alt: 2, pad: GPIO_SD_03, output: B, daisy: Some(DAISY_FLEXPWM0_PWMB1_GPIO_SD_03));
+pwm!(module: U0, submodule: U1, alt: 2, pad: GPIO_03, output: B, daisy: Some(DAISY_FLEXPWM0_PWMB1_GPIO_03));
+pwm!(module: U0, submodule: U2, alt: 2, pad: GPIO_AD_03, output: B, daisy: Some(DAISY_FLEXPWM0_PWMB2_GPIO_AD_03));
+pwm!(module: U0, submodule: U2, alt: 2, pad: GPIO_05, output: B, daisy: Some(DAISY_FLEXPWM0_PWMB2_GPIO_05));
+pwm!(module: U0, submodule: U3, alt: 2, pad: GPIO_AD_05, output: B, daisy: Some(DAISY_FLEXPWM0_PWMB3_GPIO_AD_05));
+pwm!(module: U0, submodule: U3, alt: 2, pad: GPIO_07, output: B, daisy: Some(DAISY_FLEXPWM0_PWMB3_GPIO_07));
+
+mod daisy {
+    use super::Daisy;
+
+    pub const DAISY_FLEXPWM0_PWMA0_GPIO_SD_02: Daisy = Daisy::new(0x401f8174 as *mut u32, 0);
+    pub const DAISY_FLEXPWM0_PWMA0_GPIO_02: Daisy = Daisy::new(0x401f8174 as *mut u32, 1);
+    pub const DAISY_FLEXPWM0_PWMA1_GPIO_SD_04: Daisy = Daisy::new(0x401f8178 as *mut u32, 0);
+    pub const DAISY_FLEXPWM0_PWMA1_GPIO_04: Daisy = Daisy::new(0x401f8178 as *mut u32, 1);
+    pub const DAISY_FLEXPWM0_PWMA2_GPIO_AD_04: Daisy = Daisy::new(0x401f817c as *mut u32, 0);
+    pub const DAISY_FLEXPWM0_PWMA2_GPIO_06: Daisy = Daisy::new(0x401f817c as *mut u32, 1);
+    pub const DAISY_FLEXPWM0_PWMA3_GPIO_AD_06: Daisy = Daisy::new(0x401f8180 as *mut u32, 0);
+    pub const DAISY_FLEXPWM0_PWMA3_GPIO_08: Daisy = Daisy::new(0x401f8180 as *mut u32, 1);
+    pub const DAISY_FLEXPWM0_PWMB0_GPIO_SD_01: Daisy = Daisy::new(0x401f8184 as *mut u32, 0);
+    pub const DAISY_FLEXPWM0_PWMB0_GPIO_01: Daisy = Daisy::new(0x401f8184 as *mut u32, 1);
+    pub const DAISY_FLEXPWM0_PWMB1_GPIO_SD_03: Daisy = Daisy::new(0x401f8188 as *mut u32, 0);
+    pub const DAISY_FLEXPWM0_PWMB1_GPIO_03: Daisy = Daisy::new(0x401f8188 as *mut u32, 1);
+    pub const DAISY_FLEXPWM0_PWMB2_GPIO_AD_03: Daisy = Daisy::new(0x401f818c as *mut u32, 0);
+    pub const DAISY_FLEXPWM0_PWMB2_GPIO_05: Daisy = Daisy::new(0x401f818c as *mut u32, 1);
+    pub const DAISY_FLEXPWM0_PWMB3_GPIO_AD_05: Daisy = Daisy::new(0x401f8190 as *mut u32, 0);
+    pub const DAISY_FLEXPWM0_PWMB3_GPIO_07: Daisy = Daisy::new(0x401f8190 as *mut u32, 1);
+}
+
+use daisy::*;

--- a/src/imxrt1010/lpi2c.rs
+++ b/src/imxrt1010/lpi2c.rs
@@ -12,32 +12,32 @@ use crate::{
 //
 
 // SCL
-i2c!(module: U1, alt: 0, pad: GPIO_AD_14,    signal: Scl, daisy: DAISY_LPI2C1_SCL_GPIO_AD_14);
-i2c!(module: U1, alt: 1, pad: GPIO_SD_06,    signal: Scl, daisy: DAISY_LPI2C1_SCL_GPIO_SD_06);
-i2c!(module: U1, alt: 1, pad: GPIO_12,       signal: Scl, daisy: DAISY_LPI2C1_SCL_GPIO_12);
-i2c!(module: U1, alt: 3, pad: GPIO_02,       signal: Scl, daisy: DAISY_LPI2C1_SCL_GPIO_02);
+i2c!(module: U1, alt: 0, pad: GPIO_AD_14,    signal: Scl, daisy: Some(DAISY_LPI2C1_SCL_GPIO_AD_14));
+i2c!(module: U1, alt: 1, pad: GPIO_SD_06,    signal: Scl, daisy: Some(DAISY_LPI2C1_SCL_GPIO_SD_06));
+i2c!(module: U1, alt: 1, pad: GPIO_12,       signal: Scl, daisy: Some(DAISY_LPI2C1_SCL_GPIO_12));
+i2c!(module: U1, alt: 3, pad: GPIO_02,       signal: Scl, daisy: Some(DAISY_LPI2C1_SCL_GPIO_02));
 
 // SDA
-i2c!(module: U1, alt: 0, pad: GPIO_AD_13,    signal: Sda, daisy: DAISY_LPI2C1_SDA_GPIO_AD_13);
-i2c!(module: U1, alt: 1, pad: GPIO_SD_05,    signal: Sda, daisy: DAISY_LPI2C1_SDA_GPIO_SD_05);
-i2c!(module: U1, alt: 1, pad: GPIO_11,       signal: Sda, daisy: DAISY_LPI2C1_SDA_GPIO_11);
-i2c!(module: U1, alt: 3, pad: GPIO_01,       signal: Sda, daisy: DAISY_LPI2C1_SDA_GPIO_01);
+i2c!(module: U1, alt: 0, pad: GPIO_AD_13,    signal: Sda, daisy: Some(DAISY_LPI2C1_SDA_GPIO_AD_13));
+i2c!(module: U1, alt: 1, pad: GPIO_SD_05,    signal: Sda, daisy: Some(DAISY_LPI2C1_SDA_GPIO_SD_05));
+i2c!(module: U1, alt: 1, pad: GPIO_11,       signal: Sda, daisy: Some(DAISY_LPI2C1_SDA_GPIO_11));
+i2c!(module: U1, alt: 3, pad: GPIO_01,       signal: Sda, daisy: Some(DAISY_LPI2C1_SDA_GPIO_01));
 
 //
 // I2C2
 //
 
 // SCL
-i2c!(module: U2, alt: 0, pad: GPIO_AD_08,    signal: Scl, daisy: DAISY_LPI2C2_SCL_GPIO_AD_08);
-i2c!(module: U2, alt: 1, pad: GPIO_SD_08,    signal: Scl, daisy: DAISY_LPI2C2_SCL_GPIO_SD_08);
-i2c!(module: U2, alt: 3, pad: GPIO_AD_02,    signal: Scl, daisy: DAISY_LPI2C2_SCL_GPIO_AD_02);
-i2c!(module: U2, alt: 3, pad: GPIO_10,       signal: Scl, daisy: DAISY_LPI2C2_SCL_GPIO_10);
+i2c!(module: U2, alt: 0, pad: GPIO_AD_08,    signal: Scl, daisy: Some(DAISY_LPI2C2_SCL_GPIO_AD_08));
+i2c!(module: U2, alt: 1, pad: GPIO_SD_08,    signal: Scl, daisy: Some(DAISY_LPI2C2_SCL_GPIO_SD_08));
+i2c!(module: U2, alt: 3, pad: GPIO_AD_02,    signal: Scl, daisy: Some(DAISY_LPI2C2_SCL_GPIO_AD_02));
+i2c!(module: U2, alt: 3, pad: GPIO_10,       signal: Scl, daisy: Some(DAISY_LPI2C2_SCL_GPIO_10));
 
 // SDA
-i2c!(module: U2, alt: 0, pad: GPIO_AD_07,    signal: Sda, daisy: DAISY_LPI2C2_SDA_GPIO_AD_07);
-i2c!(module: U2, alt: 1, pad: GPIO_SD_07,    signal: Sda, daisy: DAISY_LPI2C2_SDA_GPIO_SD_07);
-i2c!(module: U2, alt: 3, pad: GPIO_AD_01,    signal: Sda, daisy: DAISY_LPI2C2_SDA_GPIO_AD_01);
-i2c!(module: U2, alt: 3, pad: GPIO_09,       signal: Sda, daisy: DAISY_LPI2C2_SDA_GPIO_09);
+i2c!(module: U2, alt: 0, pad: GPIO_AD_07,    signal: Sda, daisy: Some(DAISY_LPI2C2_SDA_GPIO_AD_07));
+i2c!(module: U2, alt: 1, pad: GPIO_SD_07,    signal: Sda, daisy: Some(DAISY_LPI2C2_SDA_GPIO_SD_07));
+i2c!(module: U2, alt: 3, pad: GPIO_AD_01,    signal: Sda, daisy: Some(DAISY_LPI2C2_SDA_GPIO_AD_01));
+i2c!(module: U2, alt: 3, pad: GPIO_09,       signal: Sda, daisy: Some(DAISY_LPI2C2_SDA_GPIO_09));
 
 mod daisy {
     #![allow(unused)]

--- a/src/imxrt1020/lpi2c.rs
+++ b/src/imxrt1020/lpi2c.rs
@@ -12,48 +12,48 @@ use crate::{
 //
 
 // SCL
-i2c!(module: U1, alt: 0, pad: GPIO_AD_B1_14,  signal: Scl, daisy: DAISY_LPI2C1_SCL_GPIO_AD_B1_14);
-i2c!(module: U1, alt: 6, pad: GPIO_EMC_02,    signal: Scl, daisy: DAISY_LPI2C1_SCL_GPIO_EMC_02);
+i2c!(module: U1, alt: 0, pad: GPIO_AD_B1_14,  signal: Scl, daisy: Some(DAISY_LPI2C1_SCL_GPIO_AD_B1_14));
+i2c!(module: U1, alt: 6, pad: GPIO_EMC_02,    signal: Scl, daisy: Some(DAISY_LPI2C1_SCL_GPIO_EMC_02));
 
 // SDA
-i2c!(module: U1, alt: 0, pad: GPIO_AD_B1_15,  signal: Sda, daisy: DAISY_LPI2C1_SDA_GPIO_AD_B1_15);
-i2c!(module: U1, alt: 6, pad: GPIO_EMC_03,    signal: Sda, daisy: DAISY_LPI2C1_SDA_GPIO_EMC_03);
+i2c!(module: U1, alt: 0, pad: GPIO_AD_B1_15,  signal: Sda, daisy: Some(DAISY_LPI2C1_SDA_GPIO_AD_B1_15));
+i2c!(module: U1, alt: 6, pad: GPIO_EMC_03,    signal: Sda, daisy: Some(DAISY_LPI2C1_SDA_GPIO_EMC_03));
 
 //
 // I2C2
 //
 
 // SCL
-i2c!(module: U2, alt: 0, pad: GPIO_AD_B1_08,  signal: Scl, daisy: DAISY_LPI2C2_SCL_GPIO_AD_B1_08);
-i2c!(module: U2, alt: 2, pad: GPIO_EMC_19,    signal: Scl, daisy: DAISY_LPI2C2_SCL_GPIO_EMC_19);
+i2c!(module: U2, alt: 0, pad: GPIO_AD_B1_08,  signal: Scl, daisy: Some(DAISY_LPI2C2_SCL_GPIO_AD_B1_08));
+i2c!(module: U2, alt: 2, pad: GPIO_EMC_19,    signal: Scl, daisy: Some(DAISY_LPI2C2_SCL_GPIO_EMC_19));
 
 // SDA
-i2c!(module: U2, alt: 0, pad: GPIO_AD_B1_09,  signal: Sda, daisy: DAISY_LPI2C2_SDA_GPIO_AD_B1_09);
-i2c!(module: U2, alt: 2, pad: GPIO_EMC_18,    signal: Sda, daisy: DAISY_LPI2C2_SDA_GPIO_EMC_18);
+i2c!(module: U2, alt: 0, pad: GPIO_AD_B1_09,  signal: Sda, daisy: Some(DAISY_LPI2C2_SDA_GPIO_AD_B1_09));
+i2c!(module: U2, alt: 2, pad: GPIO_EMC_18,    signal: Sda, daisy: Some(DAISY_LPI2C2_SDA_GPIO_EMC_18));
 
 //
 // I2C3
 //
 
 // SCL
-i2c!(module: U3, alt: 1, pad: GPIO_AD_B0_08,  signal: Scl, daisy: DAISY_LPI2C3_SCL_GPIO_AD_B0_08);
-i2c!(module: U3, alt: 4, pad: GPIO_SD_B0_00,  signal: Scl, daisy: DAISY_LPI2C3_SCL_GPIO_SD_B0_00);
+i2c!(module: U3, alt: 1, pad: GPIO_AD_B0_08,  signal: Scl, daisy: Some(DAISY_LPI2C3_SCL_GPIO_AD_B0_08));
+i2c!(module: U3, alt: 4, pad: GPIO_SD_B0_00,  signal: Scl, daisy: Some(DAISY_LPI2C3_SCL_GPIO_SD_B0_00));
 
 // SDA
-i2c!(module: U3, alt: 1, pad: GPIO_AD_B0_09,  signal: Sda, daisy: DAISY_LPI2C3_SDA_GPIO_AD_B0_09);
-i2c!(module: U3, alt: 4, pad: GPIO_SD_B0_01,  signal: Sda, daisy: DAISY_LPI2C3_SDA_GPIO_SD_B0_01);
+i2c!(module: U3, alt: 1, pad: GPIO_AD_B0_09,  signal: Sda, daisy: Some(DAISY_LPI2C3_SDA_GPIO_AD_B0_09));
+i2c!(module: U3, alt: 4, pad: GPIO_SD_B0_01,  signal: Sda, daisy: Some(DAISY_LPI2C3_SDA_GPIO_SD_B0_01));
 
 //
 // I2C4
 //
 
 // SCL
-i2c!(module: U4, alt: 2, pad: GPIO_EMC_11,    signal: Scl, daisy: DAISY_LPI2C4_SCL_GPIO_EMC_11);
-i2c!(module: U4, alt: 3, pad: GPIO_SD_B1_02,  signal: Scl, daisy: DAISY_LPI2C4_SCL_GPIO_SD_B1_02);
+i2c!(module: U4, alt: 2, pad: GPIO_EMC_11,    signal: Scl, daisy: Some(DAISY_LPI2C4_SCL_GPIO_EMC_11));
+i2c!(module: U4, alt: 3, pad: GPIO_SD_B1_02,  signal: Scl, daisy: Some(DAISY_LPI2C4_SCL_GPIO_SD_B1_02));
 
 // SDA
-i2c!(module: U4, alt: 2, pad: GPIO_EMC_10,    signal: Sda, daisy: DAISY_LPI2C4_SDA_GPIO_EMC_10);
-i2c!(module: U4, alt: 3, pad: GPIO_SD_B1_03,  signal: Sda, daisy: DAISY_LPI2C4_SDA_GPIO_SD_B1_03);
+i2c!(module: U4, alt: 2, pad: GPIO_EMC_10,    signal: Sda, daisy: Some(DAISY_LPI2C4_SDA_GPIO_EMC_10));
+i2c!(module: U4, alt: 3, pad: GPIO_SD_B1_03,  signal: Sda, daisy: Some(DAISY_LPI2C4_SDA_GPIO_SD_B1_03));
 
 mod daisy {
     use super::Daisy;

--- a/src/imxrt1060/flexpwm.rs
+++ b/src/imxrt1060/flexpwm.rs
@@ -4,17 +4,78 @@ use super::pads::{gpio_ad_b0::*, gpio_b0::*, gpio_b1::*, gpio_emc::*, gpio_sd_b0
 use crate::{
     consts::*,
     flexpwm::{Pin, A, B},
+    Daisy,
 };
 
-pwm!(module: U1, submodule: U0, alt: 1, pad: GPIO_SD_B0_00, output: A);
-pwm!(module: U1, submodule: U0, alt: 1, pad: GPIO_SD_B0_01, output: B);
-pwm!(module: U1, submodule: U3, alt: 1, pad: GPIO_AD_B0_10, output: A);
-pwm!(module: U1, submodule: U3, alt: 1, pad: GPIO_AD_B0_11, output: B);
-pwm!(module: U2, submodule: U2, alt: 2, pad: GPIO_B0_10, output: A);
-pwm!(module: U2, submodule: U2, alt: 2, pad: GPIO_B0_11, output: B);
-pwm!(module: U1, submodule: U3, alt: 6, pad: GPIO_B1_01, output: B);
-pwm!(module: U1, submodule: U3, alt: 6, pad: GPIO_B1_00, output: A);
-pwm!(module: U4, submodule: U2, alt: 1, pad: GPIO_EMC_04, output: A);
-pwm!(module: U4, submodule: U2, alt: 1, pad: GPIO_EMC_05, output: B);
-pwm!(module: U2, submodule: U0, alt: 1, pad: GPIO_EMC_06, output: A);
-pwm!(module: U2, submodule: U1, alt: 1, pad: GPIO_EMC_08, output: A);
+pwm!(module: U1, submodule: U0, alt: 1, pad: GPIO_SD_B0_00, output: A, daisy: Some(DAISY_FLEXPWM1_PWMA0_GPIO_SD_B0_00));
+pwm!(module: U1, submodule: U0, alt: 1, pad: GPIO_SD_B0_01, output: B, daisy: Some(DAISY_FLEXPWM1_PWMB0_GPIO_SD_B0_01));
+pwm!(module: U1, submodule: U3, alt: 1, pad: GPIO_AD_B0_10, output: A, daisy: Some(DAISY_FLEXPWM1_PWMA3_GPIO_AD_B0_10));
+pwm!(module: U1, submodule: U3, alt: 1, pad: GPIO_AD_B0_11, output: B, daisy: Some(DAISY_FLEXPWM1_PWMB3_GPIO_AD_B0_11));
+pwm!(module: U2, submodule: U2, alt: 2, pad: GPIO_B0_10, output: A, daisy: Some(DAISY_FLEXPWM2_PWMA2_GPIO_B0_10));
+pwm!(module: U2, submodule: U2, alt: 2, pad: GPIO_B0_11, output: B, daisy: Some(DAISY_FLEXPWM2_PWMB2_GPIO_B0_11));
+pwm!(module: U1, submodule: U3, alt: 6, pad: GPIO_B1_01, output: B, daisy: Some(DAISY_FLEXPWM1_PWMB3_GPIO_B1_01));
+pwm!(module: U1, submodule: U3, alt: 6, pad: GPIO_B1_00, output: A, daisy: Some(DAISY_FLEXPWM1_PWMA3_GPIO_B1_00));
+pwm!(module: U4, submodule: U2, alt: 1, pad: GPIO_EMC_04, output: A, daisy: Some(DAISY_FLEXPWM4_PWMA2_GPIO_EMC_04));
+pwm!(module: U4, submodule: U2, alt: 1, pad: GPIO_EMC_05, output: B, daisy: None);
+pwm!(module: U2, submodule: U0, alt: 1, pad: GPIO_EMC_06, output: A, daisy: Some(DAISY_FLEXPWM2_PWMA0_GPIO_EMC_06));
+pwm!(module: U2, submodule: U1, alt: 1, pad: GPIO_EMC_08, output: A, daisy: Some(DAISY_FLEXPWM2_PWMA1_GPIO_EMC_08));
+
+mod daisy {
+    #![allow(unused)]
+    use super::Daisy;
+
+    pub const DAISY_FLEXPWM1_PWMA3_GPIO_SD_B1_00: Daisy = Daisy::new(0x401f8454 as *mut u32, 0);
+    pub const DAISY_FLEXPWM1_PWMA3_GPIO_EMC_12: Daisy = Daisy::new(0x401f8454 as *mut u32, 1);
+    pub const DAISY_FLEXPWM1_PWMA3_GPIO_EMC_38: Daisy = Daisy::new(0x401f8454 as *mut u32, 2);
+    pub const DAISY_FLEXPWM1_PWMA3_GPIO_AD_B0_10: Daisy = Daisy::new(0x401f8454 as *mut u32, 3);
+    pub const DAISY_FLEXPWM1_PWMA3_GPIO_B1_00: Daisy = Daisy::new(0x401f8454 as *mut u32, 4);
+    pub const DAISY_FLEXPWM1_PWMA0_GPIO_EMC_23: Daisy = Daisy::new(0x401f8458 as *mut u32, 0);
+    pub const DAISY_FLEXPWM1_PWMA0_GPIO_SD_B0_00: Daisy = Daisy::new(0x401f8458 as *mut u32, 1);
+    pub const DAISY_FLEXPWM1_PWMA1_GPIO_EMC_25: Daisy = Daisy::new(0x401f845c as *mut u32, 0);
+    pub const DAISY_FLEXPWM1_PWMA1_GPIO_SD_B0_02: Daisy = Daisy::new(0x401f845c as *mut u32, 1);
+    pub const DAISY_FLEXPWM1_PWMA2_GPIO_EMC_27: Daisy = Daisy::new(0x401f8460 as *mut u32, 0);
+    pub const DAISY_FLEXPWM1_PWMA2_GPIO_SD_B0_04: Daisy = Daisy::new(0x401f8460 as *mut u32, 1);
+    pub const DAISY_FLEXPWM1_PWMB3_GPIO_SD_B1_01: Daisy = Daisy::new(0x401f8464 as *mut u32, 0);
+    pub const DAISY_FLEXPWM1_PWMB3_GPIO_EMC_13: Daisy = Daisy::new(0x401f8464 as *mut u32, 1);
+    pub const DAISY_FLEXPWM1_PWMB3_GPIO_EMC_39: Daisy = Daisy::new(0x401f8464 as *mut u32, 2);
+    pub const DAISY_FLEXPWM1_PWMB3_GPIO_AD_B0_11: Daisy = Daisy::new(0x401f8464 as *mut u32, 3);
+    pub const DAISY_FLEXPWM1_PWMB3_GPIO_B1_01: Daisy = Daisy::new(0x401f8464 as *mut u32, 4);
+    pub const DAISY_FLEXPWM1_PWMB0_GPIO_EMC_24: Daisy = Daisy::new(0x401f8468 as *mut u32, 0);
+    pub const DAISY_FLEXPWM1_PWMB0_GPIO_SD_B0_01: Daisy = Daisy::new(0x401f8468 as *mut u32, 1);
+    pub const DAISY_FLEXPWM1_PWMB1_GPIO_EMC_26: Daisy = Daisy::new(0x401f846c as *mut u32, 0);
+    pub const DAISY_FLEXPWM1_PWMB1_GPIO_SD_B0_03: Daisy = Daisy::new(0x401f846c as *mut u32, 1);
+    pub const DAISY_FLEXPWM1_PWMB2_GPIO_EMC_28: Daisy = Daisy::new(0x401f8470 as *mut u32, 0);
+    pub const DAISY_FLEXPWM1_PWMB2_GPIO_SD_B0_05: Daisy = Daisy::new(0x401f8470 as *mut u32, 1);
+    pub const DAISY_FLEXPWM2_PWMA3_GPIO_SD_B1_02: Daisy = Daisy::new(0x401f8474 as *mut u32, 0);
+    pub const DAISY_FLEXPWM2_PWMA3_GPIO_EMC_19: Daisy = Daisy::new(0x401f8474 as *mut u32, 1);
+    pub const DAISY_FLEXPWM2_PWMA3_GPIO_AD_B0_00: Daisy = Daisy::new(0x401f8474 as *mut u32, 2);
+    pub const DAISY_FLEXPWM2_PWMA3_GPIO_AD_B0_09: Daisy = Daisy::new(0x401f8474 as *mut u32, 3);
+    pub const DAISY_FLEXPWM2_PWMA3_GPIO_B1_02: Daisy = Daisy::new(0x401f8474 as *mut u32, 4);
+    pub const DAISY_FLEXPWM2_PWMA0_GPIO_EMC_06: Daisy = Daisy::new(0x401f8478 as *mut u32, 0);
+    pub const DAISY_FLEXPWM2_PWMA0_GPIO_B0_06: Daisy = Daisy::new(0x401f8478 as *mut u32, 1);
+    pub const DAISY_FLEXPWM2_PWMA1_GPIO_EMC_08: Daisy = Daisy::new(0x401f847c as *mut u32, 0);
+    pub const DAISY_FLEXPWM2_PWMA1_GPIO_B0_08: Daisy = Daisy::new(0x401f847c as *mut u32, 1);
+    pub const DAISY_FLEXPWM2_PWMA2_GPIO_EMC_10: Daisy = Daisy::new(0x401f8480 as *mut u32, 0);
+    pub const DAISY_FLEXPWM2_PWMA2_GPIO_B0_10: Daisy = Daisy::new(0x401f8480 as *mut u32, 1);
+    pub const DAISY_FLEXPWM2_PWMB3_GPIO_SD_B1_03: Daisy = Daisy::new(0x401f8484 as *mut u32, 0);
+    pub const DAISY_FLEXPWM2_PWMB3_GPIO_EMC_20: Daisy = Daisy::new(0x401f8484 as *mut u32, 1);
+    pub const DAISY_FLEXPWM2_PWMB3_GPIO_AD_B0_01: Daisy = Daisy::new(0x401f8484 as *mut u32, 2);
+    pub const DAISY_FLEXPWM2_PWMB3_GPIO_B1_03: Daisy = Daisy::new(0x401f8484 as *mut u32, 3);
+    pub const DAISY_FLEXPWM2_PWMB0_GPIO_EMC_07: Daisy = Daisy::new(0x401f8488 as *mut u32, 0);
+    pub const DAISY_FLEXPWM2_PWMB0_GPIO_B0_07: Daisy = Daisy::new(0x401f8488 as *mut u32, 1);
+    pub const DAISY_FLEXPWM2_PWMB1_GPIO_EMC_09: Daisy = Daisy::new(0x401f848c as *mut u32, 0);
+    pub const DAISY_FLEXPWM2_PWMB1_GPIO_B0_09: Daisy = Daisy::new(0x401f848c as *mut u32, 1);
+    pub const DAISY_FLEXPWM2_PWMB2_GPIO_EMC_11: Daisy = Daisy::new(0x401f8490 as *mut u32, 0);
+    pub const DAISY_FLEXPWM2_PWMB2_GPIO_B0_11: Daisy = Daisy::new(0x401f8490 as *mut u32, 1);
+    pub const DAISY_FLEXPWM4_PWMA0_GPIO_EMC_00: Daisy = Daisy::new(0x401f8494 as *mut u32, 0);
+    pub const DAISY_FLEXPWM4_PWMA0_GPIO_AD_B1_08: Daisy = Daisy::new(0x401f8494 as *mut u32, 1);
+    pub const DAISY_FLEXPWM4_PWMA1_GPIO_EMC_02: Daisy = Daisy::new(0x401f8498 as *mut u32, 0);
+    pub const DAISY_FLEXPWM4_PWMA1_GPIO_AD_B1_09: Daisy = Daisy::new(0x401f8498 as *mut u32, 1);
+    pub const DAISY_FLEXPWM4_PWMA2_GPIO_EMC_04: Daisy = Daisy::new(0x401f849c as *mut u32, 0);
+    pub const DAISY_FLEXPWM4_PWMA2_GPIO_B1_14: Daisy = Daisy::new(0x401f849c as *mut u32, 1);
+    pub const DAISY_FLEXPWM4_PWMA3_GPIO_EMC_17: Daisy = Daisy::new(0x401f84a0 as *mut u32, 0);
+    pub const DAISY_FLEXPWM4_PWMA3_GPIO_B1_15: Daisy = Daisy::new(0x401f84a0 as *mut u32, 1);
+}
+
+#[allow(unused)]
+use daisy::*;

--- a/src/imxrt1060/lpi2c.rs
+++ b/src/imxrt1060/lpi2c.rs
@@ -10,8 +10,8 @@ use crate::{
 //
 // I2C1
 //
-i2c!(module: U1, alt: 3, pad: GPIO_AD_B1_00, signal: Scl, daisy: DAISY_LPI2C1_SCL_GPIO_AD_B1_00);
-i2c!(module: U1, alt: 3, pad: GPIO_AD_B1_01, signal: Sda, daisy: DAISY_LPI2C1_SDA_GPIO_AD_B1_01);
+i2c!(module: U1, alt: 3, pad: GPIO_AD_B1_00, signal: Scl, daisy: Some(DAISY_LPI2C1_SCL_GPIO_AD_B1_00));
+i2c!(module: U1, alt: 3, pad: GPIO_AD_B1_01, signal: Sda, daisy: Some(DAISY_LPI2C1_SDA_GPIO_AD_B1_01));
 
 //
 // I2C2
@@ -22,16 +22,16 @@ i2c!(module: U1, alt: 3, pad: GPIO_AD_B1_01, signal: Sda, daisy: DAISY_LPI2C1_SD
 //
 // I2C3
 //
-i2c!(module: U3, alt: 1, pad: GPIO_AD_B1_07, signal: Scl, daisy: DAISY_LPI2C3_SCL_GPIO_AD_B1_07);
-i2c!(module: U3, alt: 1, pad: GPIO_AD_B1_06, signal: Sda, daisy: DAISY_LPI2C3_SDA_GPIO_AD_B1_06);
-i2c!(module: U3, alt: 2, pad: GPIO_SD_B0_00, signal: Scl, daisy: DAISY_LPI2C3_SCL_GPIO_SD_B0_00);
-i2c!(module: U3, alt: 2, pad: GPIO_SD_B0_01, signal: Sda, daisy: DAISY_LPI2C3_SDA_GPIO_SD_B0_01);
+i2c!(module: U3, alt: 1, pad: GPIO_AD_B1_07, signal: Scl, daisy: Some(DAISY_LPI2C3_SCL_GPIO_AD_B1_07));
+i2c!(module: U3, alt: 1, pad: GPIO_AD_B1_06, signal: Sda, daisy: Some(DAISY_LPI2C3_SDA_GPIO_AD_B1_06));
+i2c!(module: U3, alt: 2, pad: GPIO_SD_B0_00, signal: Scl, daisy: Some(DAISY_LPI2C3_SCL_GPIO_SD_B0_00));
+i2c!(module: U3, alt: 2, pad: GPIO_SD_B0_01, signal: Sda, daisy: Some(DAISY_LPI2C3_SDA_GPIO_SD_B0_01));
 
 //
 // I2C4
 //
-i2c!(module: U4, alt: 0, pad: GPIO_AD_B0_12, signal: Scl, daisy: DAISY_LPI2C4_SCL_GPIO_AD_B0_12);
-i2c!(module: U4, alt: 0, pad: GPIO_AD_B0_13, signal: Sda, daisy: DAISY_LPI2C4_SDA_GPIO_AD_B0_13);
+i2c!(module: U4, alt: 0, pad: GPIO_AD_B0_12, signal: Scl, daisy: Some(DAISY_LPI2C4_SCL_GPIO_AD_B0_12));
+i2c!(module: U4, alt: 0, pad: GPIO_AD_B0_13, signal: Sda, daisy: Some(DAISY_LPI2C4_SDA_GPIO_AD_B0_13));
 
 /// Auto-generated Daisy constants
 mod daisy {

--- a/src/imxrt1170/flexpwm.rs
+++ b/src/imxrt1170/flexpwm.rs
@@ -4,9 +4,59 @@ use super::pads::gpio_ad::*;
 use crate::{
     consts::*,
     flexpwm::{Pin, A, B},
+    Daisy,
 };
 
-pwm!(module: U1, submodule: U2, alt: 4, pad: GPIO_AD_04, output: A);
-pwm!(module: U1, submodule: U2, alt: 4, pad: GPIO_AD_05, output: B);
-pwm!(module: U2, submodule: U2, alt: 4, pad: GPIO_AD_28, output: A);
-pwm!(module: U2, submodule: U2, alt: 4, pad: GPIO_AD_29, output: B);
+pwm!(module: U1, submodule: U2, alt: 4, pad: GPIO_AD_04, output: A, daisy: Some(DAISY_FLEXPWM1_PWMA2_GPIO_AD_04));
+pwm!(module: U1, submodule: U2, alt: 4, pad: GPIO_AD_05, output: B, daisy: Some(DAISY_FLEXPWM1_PWMB2_GPIO_AD_05));
+pwm!(module: U2, submodule: U2, alt: 4, pad: GPIO_AD_28, output: A, daisy: Some(DAISY_FLEXPWM2_PWMA2_GPIO_AD_28));
+pwm!(module: U2, submodule: U2, alt: 4, pad: GPIO_AD_29, output: B, daisy: Some(DAISY_FLEXPWM2_PWMB2_GPIO_AD_29));
+
+mod daisy {
+    #![allow(unused)]
+
+    use super::Daisy;
+    pub const DAISY_FLEXPWM1_PWMA0_GPIO_EMC_B1_23: Daisy = Daisy::new(0x400e8500 as *mut u32, 0);
+    pub const DAISY_FLEXPWM1_PWMA0_GPIO_AD_00: Daisy = Daisy::new(0x400e8500 as *mut u32, 1);
+    pub const DAISY_FLEXPWM1_PWMA1_GPIO_EMC_B1_25: Daisy = Daisy::new(0x400e8504 as *mut u32, 0);
+    pub const DAISY_FLEXPWM1_PWMA1_GPIO_AD_02: Daisy = Daisy::new(0x400e8504 as *mut u32, 1);
+    pub const DAISY_FLEXPWM1_PWMA2_GPIO_EMC_B1_27: Daisy = Daisy::new(0x400e8508 as *mut u32, 0);
+    pub const DAISY_FLEXPWM1_PWMA2_GPIO_AD_04: Daisy = Daisy::new(0x400e8508 as *mut u32, 1);
+    pub const DAISY_FLEXPWM1_PWMB0_GPIO_EMC_B1_24: Daisy = Daisy::new(0x400e850c as *mut u32, 0);
+    pub const DAISY_FLEXPWM1_PWMB0_GPIO_AD_01: Daisy = Daisy::new(0x400e850c as *mut u32, 1);
+    pub const DAISY_FLEXPWM1_PWMB1_GPIO_EMC_B1_26: Daisy = Daisy::new(0x400e8510 as *mut u32, 0);
+    pub const DAISY_FLEXPWM1_PWMB1_GPIO_AD_03: Daisy = Daisy::new(0x400e8510 as *mut u32, 1);
+    pub const DAISY_FLEXPWM1_PWMB2_GPIO_EMC_B1_28: Daisy = Daisy::new(0x400e8514 as *mut u32, 0);
+    pub const DAISY_FLEXPWM1_PWMB2_GPIO_AD_05: Daisy = Daisy::new(0x400e8514 as *mut u32, 1);
+    pub const DAISY_FLEXPWM2_PWMA0_GPIO_EMC_B1_06: Daisy = Daisy::new(0x400e8518 as *mut u32, 0);
+    pub const DAISY_FLEXPWM2_PWMA0_GPIO_AD_24: Daisy = Daisy::new(0x400e8518 as *mut u32, 1);
+    pub const DAISY_FLEXPWM2_PWMA1_GPIO_EMC_B1_08: Daisy = Daisy::new(0x400e851c as *mut u32, 0);
+    pub const DAISY_FLEXPWM2_PWMA1_GPIO_AD_26: Daisy = Daisy::new(0x400e851c as *mut u32, 1);
+    pub const DAISY_FLEXPWM2_PWMA2_GPIO_EMC_B1_10: Daisy = Daisy::new(0x400e8520 as *mut u32, 0);
+    pub const DAISY_FLEXPWM2_PWMA2_GPIO_AD_28: Daisy = Daisy::new(0x400e8520 as *mut u32, 1);
+    pub const DAISY_FLEXPWM2_PWMB0_GPIO_EMC_B1_07: Daisy = Daisy::new(0x400e8524 as *mut u32, 0);
+    pub const DAISY_FLEXPWM2_PWMB0_GPIO_AD_25: Daisy = Daisy::new(0x400e8524 as *mut u32, 1);
+    pub const DAISY_FLEXPWM2_PWMB1_GPIO_EMC_B1_09: Daisy = Daisy::new(0x400e8528 as *mut u32, 0);
+    pub const DAISY_FLEXPWM2_PWMB1_GPIO_AD_27: Daisy = Daisy::new(0x400e8528 as *mut u32, 1);
+    pub const DAISY_FLEXPWM2_PWMB2_GPIO_EMC_B1_11: Daisy = Daisy::new(0x400e852c as *mut u32, 0);
+    pub const DAISY_FLEXPWM2_PWMB2_GPIO_AD_29: Daisy = Daisy::new(0x400e852c as *mut u32, 1);
+    pub const DAISY_FLEXPWM3_PWMA0_GPIO_EMC_B1_29: Daisy = Daisy::new(0x400e8530 as *mut u32, 0);
+    pub const DAISY_FLEXPWM3_PWMA0_GPIO_EMC_B2_00_: Daisy = Daisy::new(0x400e8530 as *mut u32, 1);
+    pub const DAISY_FLEXPWM3_PWMA1_GPIO_EMC_B1_31: Daisy = Daisy::new(0x400e8534 as *mut u32, 0);
+    pub const DAISY_FLEXPWM3_PWMA1_GPIO_EMC_B2_02_: Daisy = Daisy::new(0x400e8534 as *mut u32, 1);
+    pub const DAISY_FLEXPWM3_PWMA2_GPIO_EMC_B1_33: Daisy = Daisy::new(0x400e8538 as *mut u32, 0);
+    pub const DAISY_FLEXPWM3_PWMA2_GPIO_EMC_B2_04_: Daisy = Daisy::new(0x400e8538 as *mut u32, 1);
+    pub const DAISY_FLEXPWM3_PWMA3_GPIO_EMC_B1_21: Daisy = Daisy::new(0x400e853c as *mut u32, 0);
+    pub const DAISY_FLEXPWM3_PWMA3_GPIO_EMC_B2_06_: Daisy = Daisy::new(0x400e853c as *mut u32, 1);
+    pub const DAISY_FLEXPWM3_PWMB0_GPIO_EMC_B1_30: Daisy = Daisy::new(0x400e8540 as *mut u32, 0);
+    pub const DAISY_FLEXPWM3_PWMB0_GPIO_EMC_B2_01_: Daisy = Daisy::new(0x400e8540 as *mut u32, 1);
+    pub const DAISY_FLEXPWM3_PWMB1_GPIO_EMC_B1_32: Daisy = Daisy::new(0x400e8544 as *mut u32, 0);
+    pub const DAISY_FLEXPWM3_PWMB1_GPIO_EMC_B2_03_: Daisy = Daisy::new(0x400e8544 as *mut u32, 1);
+    pub const DAISY_FLEXPWM3_PWMB2_GPIO_EMC_B1_34: Daisy = Daisy::new(0x400e8548 as *mut u32, 0);
+    pub const DAISY_FLEXPWM3_PWMB2_GPIO_EMC_B2_05_: Daisy = Daisy::new(0x400e8548 as *mut u32, 1);
+    pub const DAISY_FLEXPWM3_PWMB3_GPIO_EMC_B1_22: Daisy = Daisy::new(0x400e854c as *mut u32, 0);
+    pub const DAISY_FLEXPWM3_PWMB3_GPIO_EMC_B2_07_: Daisy = Daisy::new(0x400e854c as *mut u32, 1);
+}
+
+#[allow(unused)]
+use daisy::*;

--- a/src/imxrt1170/lpi2c.rs
+++ b/src/imxrt1170/lpi2c.rs
@@ -10,8 +10,8 @@ use crate::{
 //
 // I2C5
 //
-i2c!(module: U5, alt: 0, pad: GPIO_LPSR_05, signal: Scl, daisy: DAISY_LPI2C5_IPP_IND_LPI2C_SCL_SELECT_GPIO_LPSR_05);
-i2c!(module: U5, alt: 0, pad: GPIO_LPSR_04, signal: Sda, daisy: DAISY_LPI2C5_IPP_IND_LPI2C_SDA_SELECT_GPIO_LPSR_04);
+i2c!(module: U5, alt: 0, pad: GPIO_LPSR_05, signal: Scl, daisy: Some(DAISY_LPI2C5_IPP_IND_LPI2C_SCL_SELECT_GPIO_LPSR_05));
+i2c!(module: U5, alt: 0, pad: GPIO_LPSR_04, signal: Sda, daisy: Some(DAISY_LPI2C5_IPP_IND_LPI2C_SDA_SELECT_GPIO_LPSR_04));
 
 mod daisy {
     #![allow(unused)]

--- a/src/lpi2c.rs
+++ b/src/lpi2c.rs
@@ -22,7 +22,7 @@ pub trait Pin: super::Iomuxc {
     /// Alternate value for this pin
     const ALT: u32;
     /// Daisy register
-    const DAISY: super::Daisy;
+    const DAISY: Option<super::Daisy>;
     /// I2C Signal
     type Signal: Signal;
     /// I2C module; `U2` for `I2C2`
@@ -36,7 +36,9 @@ pub trait Pin: super::Iomuxc {
 pub fn prepare<P: Pin>(pin: &mut P) {
     super::alternate(pin, P::ALT);
     super::set_sion(pin);
-    unsafe { P::DAISY.write() };
+    if let Some(daisy) = P::DAISY {
+        unsafe { daisy.write() };
+    }
 }
 
 #[allow(unused)] // Used in chip-specific modules...
@@ -44,7 +46,7 @@ macro_rules! i2c {
     (module: $module:ty, alt: $alt:expr, pad: $pad:ty, signal: $signal:ty, daisy: $daisy:expr) => {
         impl Pin for $pad {
             const ALT: u32 = $alt;
-            const DAISY: Daisy = $daisy;
+            const DAISY: Option<Daisy> = $daisy;
             type Signal = $signal;
             type Module = $module;
         }


### PR DESCRIPTION
Closes #31. I believe the FlexPWM additions are non-breaking, but I'm not planning to release this in the 0.2 series right away. If you want FlexPWM daisies in a 0.2 release, ping me here now or later.

I'll sanity test this in imxrt-hal before merging.