### PR TITLE
Hard-code alternate for adc::prepare

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ All notable changes to this project will be documented in this file.
 
 - Add FlexIO pin definitions and implementations for 1060 pads.
 
+- Ensure that `adc::prepare()` configures an alternate value for ADC inputs.
+
 ## [0.2.1] 2023-02-23
 
 - Add FlexCAN pin trait with implementations for select 1060 pads.

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -24,10 +24,19 @@ pub fn prepare<P: Pin<N>, const N: u8>(pin: &mut P) {
     // GPIO, and we need to disable the keeper to prevent signal
     // jumps.
     super::configure(pin, super::Config::modify().set_pull_keeper(None));
-    // Not putting the ADC into the GPIO alternate. Reference
-    // manuals indicate that the alt (mode) doesn't matter. We're
-    // expecting that the GPIO input path is implicit, regardless
-    // of the alt.
+    // Set the GPIO alternate value.
+    //
+    // A general approach would add a constraint on the generic P for
+    // gpio::Pin<Q> (where Q is some other constant). This works, but it
+    // burdens those who design higher-level APIs, since they also need
+    // the constraint on their APIs. Hard-coding the alternate here is easier.
+    //
+    // Although not tested, it's also thought to be correct for ADC peripherals
+    // on the 1170. The ADC peripherals are in the M7 WAKEUP domain, and the alts
+    // for configuring the GPIOs for this domain are all '5'. If this call were
+    // to use the GPIO alternate for the CM4's LPSR domain (alt 10, for instance),
+    // the ADC pin may be misconfigured.
+    super::alternate(pin, 5);
 }
 
 #[allow(unused)] // Used in chip-specific modules...


### PR DESCRIPTION
Using '5' for the GPIO alternate. Troubleshooting revealed that this was necessary for a working ADC input, disputing the inline comment. It's simpler to hard-code the alt than to put the generic constraints on users.

Even though the `configure` call isn't working for the 1170, I believe '5' is also the correct alternate to set for the 1170 LPADC. See the new inline comment for the consideration.

Closes #36.