### PR TITLE
Enable open drain when preparing LPI2C pads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ All notable changes to this project will be documented in this file.
 - **BREAKING** Change the type of the `lpspi::Pin::DAISY` and `lpi2c::Pin::DAISY`
   associated constant to an `Option<Daisy>`.
 
+Enable an open drain when preparing I2C pins on 10xx MCUs.
+
 ## [0.2.3] 2023-09-09
 
 - Add FlexIO pin implementations for 1010 and 1020 pads.

--- a/src/lpi2c.rs
+++ b/src/lpi2c.rs
@@ -33,9 +33,23 @@ pub trait Pin: super::Iomuxc {
 ///
 /// If you do not call `prepare()` on your I2C pin, it might not work as a I2C
 /// pin.
+///
+/// In most build configurations, `prepare()` emits code to enable an open drain.
+/// This code is correct for all 10xx MCUs.
+///
+/// If *only* the 1170 MCU feature is enabled, then `prepare()` *does not* enable
+/// an open drain. For more information on this limitation, see
+/// [the issue tracker](https://github.com/imxrt-rs/imxrt-iomuxc/issues/28).
+///
+/// If multiple MCU features are enabled, then the `prepare()` assumes that the
+/// target MCU is a 10xx MCU. This code may execute on an 1170 MCU, but it may not
+/// work as expected.
+///
+/// `prepare()` will not touch any other bits in the PAD_CTL register.
 pub fn prepare<P: Pin>(pin: &mut P) {
     super::alternate(pin, P::ALT);
     super::set_sion(pin);
+    crate::config::set_open_drain(pin);
     if let Some(daisy) = P::DAISY {
         unsafe { daisy.write() };
     }


### PR DESCRIPTION
It's a best-effort attempt, optimizing for the 10xx MCUs. We do not enable the open drain for the 1170, and if the 1170 feature is enabled with another feature, we generate code that touches reserved fields in the PAD_CTL register.