### PR TITLE
Implement FLEXPWM Pin for all valid options (i.MX RT1060X)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to this project will be documented in this file.
 
 Enable an open drain when preparing I2C pins on 10xx MCUs.
 
+- Add remaining FlexPWM pins for the 1060 MCUs.
+
 ## [0.2.7] 2024-06-10
 
 - Fix many 1170 GPIO implementations, most which incorrectly specified their

--- a/src/imxrt1060/flexpwm.rs
+++ b/src/imxrt1060/flexpwm.rs
@@ -1,24 +1,77 @@
 //! PWM implementation
 
-use super::pads::{gpio_ad_b0::*, gpio_b0::*, gpio_b1::*, gpio_emc::*, gpio_sd_b0::*};
+use super::pads::{
+    gpio_ad_b0::*, gpio_ad_b1::*, gpio_b0::*, gpio_b1::*, gpio_emc::*, gpio_sd_b0::*, gpio_sd_b1::*,
+};
 use crate::{
     consts::*,
     flexpwm::{Pin, A, B},
     Daisy,
 };
 
+pwm!(module: U1, submodule: U0, alt: 1, pad: GPIO_EMC_23, output: A, daisy: Some(DAISY_FLEXPWM1_PWMA0_GPIO_EMC_23));
 pwm!(module: U1, submodule: U0, alt: 1, pad: GPIO_SD_B0_00, output: A, daisy: Some(DAISY_FLEXPWM1_PWMA0_GPIO_SD_B0_00));
 pwm!(module: U1, submodule: U0, alt: 1, pad: GPIO_SD_B0_01, output: B, daisy: Some(DAISY_FLEXPWM1_PWMB0_GPIO_SD_B0_01));
+pwm!(module: U1, submodule: U0, alt: 1, pad: GPIO_EMC_24, output: B, daisy: Some(DAISY_FLEXPWM1_PWMB0_GPIO_EMC_24));
+pwm!(module: U1, submodule: U1, alt: 1, pad: GPIO_EMC_25, output: A, daisy: Some(DAISY_FLEXPWM1_PWMA1_GPIO_EMC_25));
+pwm!(module: U1, submodule: U1, alt: 1, pad: GPIO_SD_B0_02, output: A, daisy: Some(DAISY_FLEXPWM1_PWMA1_GPIO_SD_B0_02));
+pwm!(module: U1, submodule: U1, alt: 1, pad: GPIO_EMC_26, output: B, daisy: Some(DAISY_FLEXPWM1_PWMB1_GPIO_EMC_26));
+pwm!(module: U1, submodule: U1, alt: 1, pad: GPIO_SD_B0_03, output: B, daisy: Some(DAISY_FLEXPWM1_PWMB1_GPIO_SD_B0_03));
+pwm!(module: U1, submodule: U2, alt: 1, pad: GPIO_SD_B0_04, output: A, daisy: Some(DAISY_FLEXPWM1_PWMA2_GPIO_SD_B0_04));
+pwm!(module: U1, submodule: U2, alt: 1, pad: GPIO_EMC_27, output: A, daisy: Some(DAISY_FLEXPWM1_PWMA2_GPIO_EMC_27));
+pwm!(module: U1, submodule: U2, alt: 1, pad: GPIO_SD_B0_05, output: B, daisy: Some(DAISY_FLEXPWM1_PWMB2_GPIO_SD_B0_05));
+pwm!(module: U1, submodule: U2, alt: 1, pad: GPIO_EMC_28, output: B, daisy: Some(DAISY_FLEXPWM1_PWMB2_GPIO_EMC_28));
+pwm!(module: U1, submodule: U3, alt: 1, pad: GPIO_EMC_38, output: A, daisy: Some(DAISY_FLEXPWM1_PWMA3_GPIO_EMC_38));
+pwm!(module: U1, submodule: U3, alt: 2, pad: GPIO_SD_B1_00, output: A, daisy: Some(DAISY_FLEXPWM1_PWMA3_GPIO_SD_B1_00));
 pwm!(module: U1, submodule: U3, alt: 1, pad: GPIO_AD_B0_10, output: A, daisy: Some(DAISY_FLEXPWM1_PWMA3_GPIO_AD_B0_10));
-pwm!(module: U1, submodule: U3, alt: 1, pad: GPIO_AD_B0_11, output: B, daisy: Some(DAISY_FLEXPWM1_PWMB3_GPIO_AD_B0_11));
-pwm!(module: U2, submodule: U2, alt: 2, pad: GPIO_B0_10, output: A, daisy: Some(DAISY_FLEXPWM2_PWMA2_GPIO_B0_10));
-pwm!(module: U2, submodule: U2, alt: 2, pad: GPIO_B0_11, output: B, daisy: Some(DAISY_FLEXPWM2_PWMB2_GPIO_B0_11));
-pwm!(module: U1, submodule: U3, alt: 6, pad: GPIO_B1_01, output: B, daisy: Some(DAISY_FLEXPWM1_PWMB3_GPIO_B1_01));
+pwm!(module: U1, submodule: U3, alt: 4, pad: GPIO_EMC_12, output: A, daisy: Some(DAISY_FLEXPWM1_PWMA3_GPIO_EMC_12));
 pwm!(module: U1, submodule: U3, alt: 6, pad: GPIO_B1_00, output: A, daisy: Some(DAISY_FLEXPWM1_PWMA3_GPIO_B1_00));
+pwm!(module: U1, submodule: U3, alt: 1, pad: GPIO_EMC_39, output: B, daisy: Some(DAISY_FLEXPWM1_PWMB3_GPIO_EMC_39));
+pwm!(module: U1, submodule: U3, alt: 6, pad: GPIO_B1_01, output: B, daisy: Some(DAISY_FLEXPWM1_PWMB3_GPIO_B1_01));
+pwm!(module: U1, submodule: U3, alt: 1, pad: GPIO_AD_B0_11, output: B, daisy: Some(DAISY_FLEXPWM1_PWMB3_GPIO_AD_B0_11));
+pwm!(module: U1, submodule: U3, alt: 2, pad: GPIO_SD_B1_01, output: B, daisy: Some(DAISY_FLEXPWM1_PWMB3_GPIO_SD_B1_01));
+pwm!(module: U1, submodule: U3, alt: 4, pad: GPIO_EMC_13, output: B, daisy: Some(DAISY_FLEXPWM1_PWMB3_GPIO_EMC_13));
+pwm!(module: U2, submodule: U0, alt: 2, pad: GPIO_B0_06, output: A, daisy: Some(DAISY_FLEXPWM2_PWMA0_GPIO_B0_06));
+pwm!(module: U2, submodule: U0, alt: 1, pad: GPIO_EMC_06, output: A, daisy: Some(DAISY_FLEXPWM2_PWMA0_GPIO_EMC_06));
+pwm!(module: U2, submodule: U0, alt: 2, pad: GPIO_B0_07, output: B, daisy: Some(DAISY_FLEXPWM2_PWMB0_GPIO_B0_07));
+pwm!(module: U2, submodule: U0, alt: 1, pad: GPIO_EMC_07, output: B, daisy: Some(DAISY_FLEXPWM2_PWMB0_GPIO_EMC_07));
+pwm!(module: U2, submodule: U1, alt: 1, pad: GPIO_EMC_08, output: A, daisy: Some(DAISY_FLEXPWM2_PWMA1_GPIO_EMC_08));
+pwm!(module: U2, submodule: U1, alt: 2, pad: GPIO_B0_08, output: A, daisy: Some(DAISY_FLEXPWM2_PWMA1_GPIO_B0_08));
+pwm!(module: U2, submodule: U1, alt: 1, pad: GPIO_EMC_09, output: B, daisy: Some(DAISY_FLEXPWM2_PWMB1_GPIO_EMC_09));
+pwm!(module: U2, submodule: U1, alt: 2, pad: GPIO_B0_09, output: B, daisy: Some(DAISY_FLEXPWM2_PWMB1_GPIO_B0_09));
+pwm!(module: U2, submodule: U2, alt: 1, pad: GPIO_EMC_10, output: A, daisy: Some(DAISY_FLEXPWM2_PWMA2_GPIO_EMC_10));
+pwm!(module: U2, submodule: U2, alt: 2, pad: GPIO_B0_10, output: A, daisy: Some(DAISY_FLEXPWM2_PWMA2_GPIO_B0_10));
+pwm!(module: U2, submodule: U2, alt: 1, pad: GPIO_EMC_11, output: B, daisy: Some(DAISY_FLEXPWM2_PWMB2_GPIO_EMC_11));
+pwm!(module: U2, submodule: U2, alt: 2, pad: GPIO_B0_11, output: B, daisy: Some(DAISY_FLEXPWM2_PWMB2_GPIO_B0_11));
+pwm!(module: U2, submodule: U3, alt: 1, pad: GPIO_AD_B0_09, output: A, daisy: Some(DAISY_FLEXPWM2_PWMA3_GPIO_AD_B0_09));
+pwm!(module: U2, submodule: U3, alt: 2, pad: GPIO_SD_B1_02, output: A, daisy: Some(DAISY_FLEXPWM2_PWMA3_GPIO_SD_B1_02));
+pwm!(module: U2, submodule: U3, alt: 1, pad: GPIO_EMC_19, output: A, daisy: Some(DAISY_FLEXPWM2_PWMA3_GPIO_EMC_19));
+pwm!(module: U2, submodule: U3, alt: 6, pad: GPIO_B1_02, output: A, daisy: Some(DAISY_FLEXPWM2_PWMA3_GPIO_B1_02));
+pwm!(module: U2, submodule: U3, alt: 0, pad: GPIO_AD_B0_00, output: A, daisy: Some(DAISY_FLEXPWM2_PWMA3_GPIO_AD_B0_00));
+pwm!(module: U2, submodule: U3, alt: 0, pad: GPIO_AD_B0_01, output: B, daisy: Some(DAISY_FLEXPWM2_PWMB3_GPIO_AD_B0_01));
+pwm!(module: U2, submodule: U3, alt: 2, pad: GPIO_SD_B1_03, output: B, daisy: Some(DAISY_FLEXPWM2_PWMB3_GPIO_SD_B1_03));
+pwm!(module: U2, submodule: U3, alt: 6, pad: GPIO_B1_03, output: B, daisy: Some(DAISY_FLEXPWM2_PWMB3_GPIO_B1_03));
+pwm!(module: U2, submodule: U3, alt: 1, pad: GPIO_EMC_20, output: B, daisy: Some(DAISY_FLEXPWM2_PWMB3_GPIO_EMC_20));
+pwm!(module: U3, submodule: U0, alt: 1, pad: GPIO_EMC_29, output: A, daisy: None);
+pwm!(module: U3, submodule: U0, alt: 1, pad: GPIO_EMC_30, output: B, daisy: None);
+pwm!(module: U3, submodule: U1, alt: 1, pad: GPIO_EMC_31, output: A, daisy: None);
+pwm!(module: U3, submodule: U1, alt: 1, pad: GPIO_EMC_32, output: B, daisy: None);
+pwm!(module: U3, submodule: U2, alt: 1, pad: GPIO_EMC_33, output: A, daisy: None);
+pwm!(module: U3, submodule: U2, alt: 1, pad: GPIO_EMC_34, output: B, daisy: None);
+pwm!(module: U3, submodule: U3, alt: 1, pad: GPIO_EMC_21, output: A, daisy: None);
+pwm!(module: U3, submodule: U3, alt: 1, pad: GPIO_EMC_22, output: B, daisy: None);
+pwm!(module: U4, submodule: U0, alt: 1, pad: GPIO_AD_B1_08, output: A, daisy: Some(DAISY_FLEXPWM4_PWMA0_GPIO_AD_B1_08));
+pwm!(module: U4, submodule: U0, alt: 1, pad: GPIO_EMC_00, output: A, daisy: Some(DAISY_FLEXPWM4_PWMA0_GPIO_EMC_00));
+pwm!(module: U4, submodule: U0, alt: 1, pad: GPIO_EMC_01, output: B, daisy: None);
+pwm!(module: U4, submodule: U1, alt: 1, pad: GPIO_AD_B1_09, output: A, daisy: Some(DAISY_FLEXPWM4_PWMA1_GPIO_AD_B1_09));
+pwm!(module: U4, submodule: U1, alt: 1, pad: GPIO_EMC_02, output: A, daisy: Some(DAISY_FLEXPWM4_PWMA1_GPIO_EMC_02));
+pwm!(module: U4, submodule: U1, alt: 1, pad: GPIO_EMC_03, output: B, daisy: None);
+pwm!(module: U4, submodule: U2, alt: 1, pad: GPIO_B1_14, output: A, daisy: Some(DAISY_FLEXPWM4_PWMA2_GPIO_B1_14));
 pwm!(module: U4, submodule: U2, alt: 1, pad: GPIO_EMC_04, output: A, daisy: Some(DAISY_FLEXPWM4_PWMA2_GPIO_EMC_04));
 pwm!(module: U4, submodule: U2, alt: 1, pad: GPIO_EMC_05, output: B, daisy: None);
-pwm!(module: U2, submodule: U0, alt: 1, pad: GPIO_EMC_06, output: A, daisy: Some(DAISY_FLEXPWM2_PWMA0_GPIO_EMC_06));
-pwm!(module: U2, submodule: U1, alt: 1, pad: GPIO_EMC_08, output: A, daisy: Some(DAISY_FLEXPWM2_PWMA1_GPIO_EMC_08));
+pwm!(module: U4, submodule: U3, alt: 1, pad: GPIO_B1_15, output: A, daisy: Some(DAISY_FLEXPWM4_PWMA3_GPIO_B1_15));
+pwm!(module: U4, submodule: U3, alt: 1, pad: GPIO_EMC_17, output: A, daisy: Some(DAISY_FLEXPWM4_PWMA3_GPIO_EMC_17));
+pwm!(module: U4, submodule: U3, alt: 1, pad: GPIO_EMC_18, output: B, daisy: None);
 
 mod daisy {
     #![allow(unused)]


### PR DESCRIPTION
Hi all,

I'm not sure if the limited number of existing FLEXPWM Pin implementations was intentional, but in case it wasn't and it just needed someone to copy the information from the reference manual, I've gone ahead and done that here. 

The git diff shows a couple of "modifications", I haven't actually modified the existing pin implementations, but I did re-arrange the macro invocations in the order shown in the reference manual to make it easier to understand.

I've been as thorough as I can to make sure all the new (and existing) implementation information is correct, but it's probably a good idea for someone to double check it as well just in case.

If this PR isn't wanted or needed go ahead and close it, but far more pins on a Teensy 4 are advertised with PWM than supported by `imxrt-hal`, this PR would fix that.

I welcome any feedback on changes I might need, this is my first contribution at this low-level :)